### PR TITLE
Reserve `pvz` alias for a future project

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,3 +64,22 @@ repos:
       - id: taplo-format
         # See options: https://taplo.tamasfe.dev/configuration/formatter-options.html
         args: [--option, "reorder_arrays=true", --option, "reorder_keys=true"]
+
+  - repo: local
+    hooks:
+      - id: forbid-pvz
+        name: Forbid 'pvz' alias (reserved for another project; use 'zstd')
+        entry: |
+          bash -c '
+            matches=$(grep -HnE "\bpvz\b" "$@" 2>/dev/null || true)
+            if [ -n "$matches" ]; then
+              echo "$matches"
+              echo
+              echo "'\''pvz'\'' is reserved — use \`import pyvista_zstd as zstd\` instead. (ask @banesullivan)"
+              exit 1
+            fi
+          ' --
+        language: system
+        types: [text]
+        require_serial: true
+        exclude: ^\.pre-commit-config\.yaml$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,14 +68,14 @@ repos:
   - repo: local
     hooks:
       - id: forbid-pvz
-        name: Forbid 'pvz' alias (reserved for another project; use 'zstd')
+        name: Forbid 'pvz' alias (reserved for another project; use 'pvzstd')
         entry: |
           bash -c '
             matches=$(grep -HnE "\bpvz\b" "$@" 2>/dev/null || true)
             if [ -n "$matches" ]; then
               echo "$matches"
               echo
-              echo "'\''pvz'\'' is reserved — use \`import pyvista_zstd as zstd\` instead. (ask @banesullivan)"
+              echo "'\''pvz'\'' is reserved — use \`import pyvista_zstd as pvzstd\` instead. (ask @banesullivan)"
               exit 1
             fi
           ' --


### PR DESCRIPTION
- Add a local pre-commit hook that forbids the literal `pvz` (as a whole word) anywhere in the repo, not just in imports, so there is no ambiguity between this project and a separate upcoming one I am planning to release.
- On match, the hook prints the offending file and line followed by a single-line note telling contributors to use `import pyvista_zstd as pvzstd` instead, and to reach out to @banesullivan with questions.
- Uses `language: system` with a small bash block and `require_serial: true` so all matches are collected into one invocation and the explanation is only shown once.
- Kindly asking to please reserve `pvz` here so it stays available for the future project; happy to discuss alternative aliases if anyone has a strong preference.

Preview:
```
Forbid 'pvz' alias (reserved for another project; use 'zstd').......................Failed
- hook id: forbid-pvz
- exit code: 1

README.rst:25:pvz
tests/conftest.py:38:    import pyvista_zstd as pvz

'pvz' is reserved — use `import pyvista_zstd as pvzstd` instead. (ask @banesullivan)
```