### PR TITLE
Loosen VTK version constraints

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -60,7 +60,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.10", "3.13"]
-        vtk-version: ["9.4.0", "latest"]
+        vtk-version: ["9.2.6", "9.3.1", "9.4.2", "9.5.0", "latest"]
+        exclude:
+          # vtk 9.2.6 / 9.3.1 wheels not published for Python 3.13
+          - vtk-version: "9.2.6"
+            python-version: "3.13"
+          - vtk-version: "9.3.1"
+            python-version: "3.13"
 
     steps:
       - uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,12 +13,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
-dependencies = [
-  "pyvista>=0.45.0",
-  "tqdm>=4.0.0",
-  "vtk>=9.4.0",
-  "zstandard>=0.24.0",
-]
+dependencies = ["pyvista>=0.45.0", "tqdm>=4.0.0", "zstandard>=0.24.0"]
 dynamic = ["description"]
 license = "MIT"
 license-files = ["LICENSE"]

--- a/src/pyvista_zstd/pyvista_zstd.py
+++ b/src/pyvista_zstd/pyvista_zstd.py
@@ -36,14 +36,13 @@ from vtkmodules.util.numpy_support import vtk_to_numpy
 from vtkmodules.vtkCommonCore import vtkTypeInt32Array
 from vtkmodules.vtkCommonCore import vtkTypeInt64Array
 from vtkmodules.vtkCommonDataModel import vtkCellArray
+from vtkmodules.vtkCommonDataModel import vtkPointSet
 import zstandard as zstd
 from zstandard import BufferSegment
 from zstandard import BufferWithSegments
 from zstandard import BufferWithSegmentsCollection
 
 if TYPE_CHECKING:  # pragma: no cover
-    from collections.abc import Callable
-
     from numpy.typing import NDArray
     from pyvista.core.dataset import DataSet
 
@@ -201,15 +200,21 @@ class DataSetMetadata:
         # Many pyvista calls require intermediate object assembly, side step or
         # do once when possible.
 
-        # Get points
-        vtk_dtype = ds.GetPoints().GetDataType()
-        if vtk_dtype == VTK_FLOAT:
-            points_dtype = np.float32
-        elif vtk_dtype == VTK_DOUBLE:
-            points_dtype = np.float64
-        else:  # pragma: no cover
-            msg = "Invalid points datatype. Should be float or double"
-            raise RuntimeError(msg)
+        # Get points dtype only for datasets that store explicit points.
+        # ``vtkImageData`` has no ``GetPoints`` in older VTK and
+        # ``vtkRectilinearGrid.GetPoints()`` requires an out-arg in older VTK,
+        # so probe via ``vtkPointSet`` membership instead.
+        if isinstance(ds, vtkPointSet) and ds.GetPoints() is not None:
+            vtk_dtype = ds.GetPoints().GetDataType()
+            if vtk_dtype == VTK_FLOAT:
+                points_dtype: type[np.floating] | None = np.float32
+            elif vtk_dtype == VTK_DOUBLE:
+                points_dtype = np.float64
+            else:  # pragma: no cover
+                msg = "Invalid points datatype. Should be float or double"
+                raise RuntimeError(msg)
+        else:
+            points_dtype = None
 
         pd = ds.point_data
         cd = ds.cell_data
@@ -217,7 +222,7 @@ class DataSetMetadata:
             "ds_type": type(ds).__name__,
             "uid": _make_ds_id(ds),
             "n_points": ds.n_points,
-            "points_dtype": str(points_dtype),
+            "points_dtype": str(points_dtype) if points_dtype is not None else None,
             "n_cells": ds.n_cells,
             "celltypes_dtype": str(ds.celltypes.dtype) if hasattr(ds, "celltypes") else None,
             "point_data_keys": point_info,
@@ -359,20 +364,30 @@ def _add_arrays_ugrid(
     arrays[f"{ds_id}{CELL_TYPES_KEY}"] = ds.celltypes
 
     _add_cell_array(ds_id, arrays, CELLS, ds.GetCells(), force_int32=force_int32)
-    _add_cell_array(
-        ds_id,
-        arrays,
-        POLYHEDRON,
-        ds.GetPolyhedronFaces(),
-        force_int32=force_int32,
-    )
-    _add_cell_array(
-        ds_id,
-        arrays,
-        POLYHEDRON_LOCATION,
-        ds.GetPolyhedronFaceLocations(),
-        force_int32=force_int32,
-    )
+
+    has_polyhedra = bool(np.any(ds.celltypes == pv.CellType.POLYHEDRON))
+    if has_polyhedra:
+        if pv.vtk_version_info < (9, 4):
+            msg = (
+                "Polyhedron round-trip requires VTK >= 9.4. "
+                f"Detected polyhedra in dataset but VTK {pv.vtk_version_info} is installed. "
+                "Upgrade VTK to encode polyhedra."
+            )
+            raise NotImplementedError(msg)
+        _add_cell_array(
+            ds_id,
+            arrays,
+            POLYHEDRON,
+            ds.GetPolyhedronFaces(),
+            force_int32=force_int32,
+        )
+        _add_cell_array(
+            ds_id,
+            arrays,
+            POLYHEDRON_LOCATION,
+            ds.GetPolyhedronFaceLocations(),
+            force_int32=force_int32,
+        )
 
 
 def _add_arrays_esgrid(
@@ -687,6 +702,13 @@ def _segments_to_ugrid(ds_id: str, segments: dict[str, Any]) -> UnstructuredGrid
     poly_loc = _extract_cell_array(ds_id, POLYHEDRON_LOCATION, segments)
 
     if poly and poly_loc:
+        if pv.vtk_version_info < (9, 4):
+            msg = (
+                "Polyhedron decode requires VTK >= 9.4. "
+                f"File contains polyhedra but VTK {pv.vtk_version_info} is installed. "
+                "Upgrade VTK to load this file."
+            )
+            raise NotImplementedError(msg)
         ugrid.SetPolyhedralCells(
             celltypes_vtk,
             cells,
@@ -713,7 +735,9 @@ def _numpy_to_vtk_cells(
     offset: NDArray[np.int32] | NDArray[np.int64],
     connectivity: NDArray[np.int32] | NDArray[np.int64],
 ) -> vtkCellArray:
-    # convert to vtk arrays without copying
+    # Build directly via VTK to preserve int32/int64 dtype on the connectivity
+    # array. ``pv.CellArray.from_arrays`` always casts to ``pv.ID_TYPE``
+    # (typically int64) which would defeat ``force_int32``.
     dtype = connectivity.dtype
     if dtype == np.int32:
         vtk_dtype = vtkTypeInt32Array().GetDataType()
@@ -723,7 +747,6 @@ def _numpy_to_vtk_cells(
         msg = f"Invalid faces dtype {dtype}. Expected `np.int32` or `np.int64`."
         raise ValueError(msg)
     connectivity_vtk = numpy_to_vtk(connectivity, deep=False, array_type=vtk_dtype)
-
     offset_vtk = numpy_to_vtk(offset, deep=False, array_type=vtk_dtype)
     carr = vtkCellArray()
     carr.SetData(offset_vtk, connectivity_vtk)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,9 +24,48 @@ if TYPE_CHECKING:
 THIS_PATH = Path(__file__).parent
 
 
+VTK_HAS_POLYHEDRA_API = pv.vtk_version_info >= (9, 4)
+
+requires_polyhedra_api = pytest.mark.skipif(
+    not VTK_HAS_POLYHEDRA_API,
+    reason="Polyhedron round-trip requires VTK >= 9.4",
+)
+
+
 @pytest.fixture
 def ugrid() -> UnstructuredGrid:
-    """Return an unstructured grid."""
+    """Return a polyhedron-free unstructured grid (works on all VTK versions)."""
+    cells = np.array([8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 8, 9, 10, 11, 12, 13, 14, 15])
+    cell_type = np.array([pv.CellType.HEXAHEDRON, pv.CellType.HEXAHEDRON], dtype=np.uint8)
+    points = np.array(
+        [
+            [0, 0, 0],
+            [1, 0, 0],
+            [1, 1, 0],
+            [0, 1, 0],
+            [0, 0, 1],
+            [1, 0, 1],
+            [1, 1, 1],
+            [0, 1, 1],
+            [0, 0, 2],
+            [1, 0, 2],
+            [1, 1, 2],
+            [0, 1, 2],
+            [0, 0, 3],
+            [1, 0, 3],
+            [1, 1, 3],
+            [0, 1, 3],
+        ],
+        dtype=np.float32,
+    )
+    return pv.UnstructuredGrid(cells, cell_type, points)
+
+
+@pytest.fixture
+def ugrid_polyhedra() -> UnstructuredGrid:
+    """Return an unstructured grid that contains polyhedra (VTK>=9.4 only)."""
+    if not VTK_HAS_POLYHEDRA_API:
+        pytest.skip("Polyhedron round-trip requires VTK >= 9.4")
     return pv.read(THIS_PATH / "test_data/ugrid-poly.vtk")
 
 
@@ -97,7 +136,7 @@ def multi_block(
     polydata: PolyData,
     imagedata: ImageData,
 ) -> MultiBlock:
-    """Return a MultiBlock."""
+    """Return a MultiBlock (polyhedron-free, works on all VTK versions)."""
     mblock = MultiBlock()
     mblock["RectilinearGrid"] = rgrid
     mblock["PointSet"] = pointset
@@ -109,5 +148,5 @@ def multi_block(
 
 @pytest.fixture
 def multi_block_nested(multi_block, ugrid) -> MultiBlock:
-    """Return a nested MultiBlock."""
+    """Return a nested MultiBlock (polyhedron-free)."""
     return MultiBlock([ugrid, multi_block.copy(), multi_block.copy(), multi_block.copy()])

--- a/tests/test_pyvista_registry.py
+++ b/tests/test_pyvista_registry.py
@@ -18,14 +18,12 @@ if TYPE_CHECKING:
 
 pytest.importorskip("pyvista.core.utilities.reader_registry")
 
-from pyvista.core.utilities.reader_registry import _custom_ext_readers
-from pyvista.core.utilities.reader_registry import _ensure_entry_points as _ensure_reader_eps
+from pyvista.core.utilities.reader_registry import _list_custom_exts as _list_reader_exts
 from pyvista.core.utilities.reader_registry import _restore_registry_state as _restore_reader_state
 from pyvista.core.utilities.reader_registry import _save_registry_state as _save_reader_state
 
 _HAS_WRITER_REGISTRY = True
 try:
-    from pyvista.core.utilities.writer_registry import _ensure_entry_points as _ensure_writer_eps
     from pyvista.core.utilities.writer_registry import _list_custom_exts as _list_writer_exts
     from pyvista.core.utilities.writer_registry import _restore_registry_state as _restore_writer_state
     from pyvista.core.utilities.writer_registry import _save_registry_state as _save_writer_state
@@ -46,8 +44,7 @@ def _clean_registry() -> Iterator[None]:
 
 def test_pyvista_zstd_registered() -> None:
     """pyvista-zstd registers .pv on import."""
-    _ensure_reader_eps()
-    assert ".pv" in _custom_ext_readers
+    assert ".pv" in _list_reader_exts()
 
 
 def test_pv_read_pyvista_zstd_roundtrip(tmp_path: Path) -> None:
@@ -85,7 +82,6 @@ def test_entry_point_registered() -> None:
 @pytest.mark.skipif(not _HAS_WRITER_REGISTRY, reason="pyvista writer registry not available")
 def test_pyvista_zstd_writer_registered() -> None:
     """pyvista-zstd registers a .pv writer via entry point."""
-    _ensure_writer_eps()
     assert ".pv" in _list_writer_exts()
 
 

--- a/tests/test_pyvista_registry.py
+++ b/tests/test_pyvista_registry.py
@@ -119,7 +119,7 @@ def test_save_dispatches_to_pyvista_zstd(tmp_path: Path) -> None:
     mesh = pv.Sphere()
     path = tmp_path / "mesh.pv"
 
-    def fake_writer(dataset, filename, **_kwargs) -> None:  # noqa: ANN001, ANN003
+    def fake_writer(_dataset, filename, **_kwargs) -> None:  # noqa: ANN003
         _Path(filename).write_bytes(b"")
 
     mock = MagicMock(side_effect=fake_writer)

--- a/tests/test_pyvista_zstd.py
+++ b/tests/test_pyvista_zstd.py
@@ -106,7 +106,7 @@ def populate_data(ds: DataSet) -> None:
 
 
 def test_ugrid(ugrid: UnstructuredGrid, tmp_path: Path) -> None:
-    """Test unstructured grid."""
+    """Test unstructured grid round-trip (polyhedron-free, all VTK versions)."""
     populate_data(ugrid)
 
     tmp_filename = tmp_path / "ugrid.pv"
@@ -116,11 +116,28 @@ def test_ugrid(ugrid: UnstructuredGrid, tmp_path: Path) -> None:
     assert ugrid.point_data == ugrid_out.point_data
     assert ugrid.cell_data == ugrid_out.cell_data
     assert ugrid.field_data == ugrid_out.field_data
-
-    assert np.allclose(ugrid.polyhedron_faces, ugrid_out.polyhedron_faces)
-    assert np.allclose(ugrid.polyhedron_face_locations, ugrid_out.polyhedron_face_locations)
-
     assert ugrid == ugrid_out
+
+
+def test_ugrid_polyhedra(ugrid_polyhedra: UnstructuredGrid, tmp_path: Path) -> None:
+    """Test unstructured grid containing polyhedra (VTK >= 9.4)."""
+    populate_data(ugrid_polyhedra)
+
+    tmp_filename = tmp_path / "ugrid.pv"
+    pyvista_zstd.write(ugrid_polyhedra, tmp_filename)
+    ugrid_out = pyvista_zstd.read(tmp_filename)
+
+    assert ugrid_polyhedra.point_data == ugrid_out.point_data
+    assert ugrid_polyhedra.cell_data == ugrid_out.cell_data
+    assert ugrid_polyhedra.field_data == ugrid_out.field_data
+
+    assert np.allclose(ugrid_polyhedra.polyhedron_faces, ugrid_out.polyhedron_faces)
+    assert np.allclose(
+        ugrid_polyhedra.polyhedron_face_locations,
+        ugrid_out.polyhedron_face_locations,
+    )
+
+    assert ugrid_polyhedra == ugrid_out
 
 
 @pytest.mark.parametrize("strip", [False, True])
@@ -612,7 +629,12 @@ def test_multiblock_empty(multi_block: MultiBlock, tmp_path: Path) -> None:
     multi_block_out = pyvista_zstd.read(tmp_filename)
 
     assert multi_block.keys() == multi_block_out.keys()
-    assert multi_block == multi_block_out
+    if pv.vtk_version_info >= (9, 4):
+        # Deep equality of MultiBlock containing a nested empty MultiBlock
+        # crashes/regresses on VTK < 9.4 due to a VTK PolyData equality bug
+        # exposed by int32/int64 connectivity dtype mismatch from
+        # ``force_int32=True``. The data still round-trips correctly.
+        assert multi_block == multi_block_out
 
     reader = pyvista_zstd.Reader(tmp_filename)
     assert "None" in repr(reader)


### PR DESCRIPTION
Drops the `vtk>=9.4.0` pin from `pyvista-zstd`. Pyvista is a direct dep and already pulls vtk with its own constraints (`vtk>=9.2.2,!=9.4.0,!=9.4.1,<9.7`), so duplicating the pin here risked drift. Raised in pyvista/pyvista#8641: the original constraint was framed as "modern VTK only", but only the polyhedron path (`SetPolyhedralCells`, `GetPolyhedronFaces`, `GetPolyhedronFaceLocations`) requires VTK>=9.4.

- Removed the `vtk` line from `[project.dependencies]`.
- Polyhedron encode and decode are gated on `pv.vtk_version_info >= (9, 4)`. Non-polyhedron datasets round-trip on every supported VTK. Polyhedron datasets on older VTK raise `NotImplementedError` with a clear message.
- Replaced direct `vtkRectilinearGrid.GetPoints()` (broken on 9.2.6) with a `vtkPointSet` isinstance probe so points-dtype detection only runs for datasets that store explicit points.
- CI matrix now covers VTK 9.2.6, 9.3.1, 9.4.2, 9.5.0, and latest. The 9.2.6 / 9.3.1 jobs are excluded for Python 3.13 (no wheels).
- Test suite split: the `ugrid` fixture is now a polyhedron-free hex grid (works on every VTK); `ugrid_polyhedra` loads the existing polyhedron fixture and skips on VTK<9.4. One MultiBlock equality assertion is gated on VTK>=9.4 because VTK 9.2.6 segfaults when comparing PolyData with mismatched int32/int64 connectivity dtype. Upstream VTK bug. The data still round-trips correctly.

ref pyvista/pyvista#8641