### PR TITLE
Add lossless mesh filters for triangle storage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,13 @@ the redundant offsets array. This applies to triangles, quads, tetrahedra, and
 any other fixed-width cell topology. Mixed-width cell arrays retain their
 explicit offsets.
 
+Explicit point coordinates and homogeneous triangle connectivity also use
+lossless mesh-specific transforms by default when a quick trial compression
+shows they reduce the output. Coordinate components are grouped into separate
+byte planes, while consecutive triangle index triplets are differenced and
+byte-shuffled. Pass ``mesh_filters=False`` to ``write`` when format-version-2
+compatibility is required.
+
 **Alternative VTK example**
 
 .. code:: py

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -35,3 +35,31 @@ Reads spend 1.00 to 12.93 ms in the corresponding decoders. Automatic writes
 add another 4.86 to 11.28 ms to decide whether the filters are worthwhile. The
 fixed probe cost dominates the two smallest examples; forcing the transforms
 is therefore faster when the caller already knows that storage is the priority.
+
+### Relative CPU cost
+
+These percentages normalize the direct costs against the corresponding
+format-version-2 end-to-end operation. They come from an 11-repeat run pinned
+to one CPU core; the three synthetic datasets use five timed repeats under the
+benchmark's large-mesh policy.
+
+| Dataset              | Encoders / v2 write | Auto probes / v2 write | Decoders / v2 read |
+| -------------------- | ------------------: | ---------------------: | -----------------: |
+| Synthetic ordered    |                5.6% |                   4.7% |              22.3% |
+| Synthetic scrambled  |                5.4% |                   4.3% |              36.3% |
+| Synthetic random     |                7.1% |                   3.5% |              57.4% |
+| PyVista bunny        |                6.6% |                  51.6% |              29.8% |
+| PyVista horse        |                6.5% |                  74.7% |              27.8% |
+| PyVista woman        |                7.7% |                  24.6% |              29.1% |
+| PyVista Louis Louvre |                5.9% |                   9.9% |              32.5% |
+
+The encoders add 5.4 to 7.7 percent of the previous total write time. The
+decoders add 22.3 to 57.4 percent of the previous total read time; the real
+example meshes cluster between 27.8 and 32.5 percent. Automatic selection adds
+3.5 to 74.7 percent of the previous write time. That range is size-dependent:
+the fixed probe is 3.5 to 4.7 percent on the million-triangle synthetic meshes
+but 51.6 to 74.7 percent on bunny and horse.
+
+These are gross CPU costs before accounting for the reduced zstd workload. The
+end-to-end results can still be faster because the transformed representation
+compresses more quickly and produces fewer bytes.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,3 +1,12 @@
 ### `pyvista-zstd` Benchmarks
 
 This directory contains benchmark scripts for `pyvista-zstd`.
+
+`benchmark-mesh-filters.py` compares format-version-2 storage with forced and
+automatically selected format-version-3 mesh filters. It measures direct
+transform/probe cost plus end-to-end write time, read time, and file size on
+ordered, scrambled, and incompressible random synthetic triangle meshes and
+real meshes from `pyvista.examples`.
+
+The example download functions use PyVista's normal data cache and may fetch a
+mesh on the first run. Dataset loading is completed before timing starts.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -10,3 +10,28 @@ real meshes from `pyvista.examples`.
 
 The example download functions use PyVista's normal data cache and may fetch a
 mesh on the first run. Dataset loading is completed before timing starts.
+
+### Measured transform cost
+
+The table below reports the direct CPU cost of the current implementation. The
+values are medians in milliseconds after an untimed warmup on an Intel Xeon
+E-2288G, using the default benchmark sizes, single-threaded zstd level 3,
+Python 3.13.11, PyVista 0.48.4, VTK 9.6.2, and NumPy 2.5.1. The point and
+connectivity probe columns are added together by automatic mode. Forced mode
+skips both probes.
+
+| Dataset              | Point encode | Point decode | Triangle encode | Triangle decode | Auto probes |
+| -------------------- | -----------: | -----------: | --------------: | --------------: | ----------: |
+| Synthetic ordered    |      4.94 ms |      3.26 ms |         8.18 ms |         9.66 ms |     8.61 ms |
+| Synthetic scrambled  |      4.78 ms |      3.28 ms |         6.92 ms |        10.44 ms |     8.56 ms |
+| Synthetic random     |      3.22 ms |      2.77 ms |         6.52 ms |         9.98 ms |     4.86 ms |
+| PyVista bunny        |      0.30 ms |      0.26 ms |         0.57 ms |         0.74 ms |     6.70 ms |
+| PyVista horse        |      0.28 ms |      0.27 ms |         0.54 ms |         0.74 ms |    10.16 ms |
+| PyVista woman        |      1.03 ms |      1.00 ms |         2.32 ms |         2.95 ms |    11.28 ms |
+| PyVista Louis Louvre |      1.47 ms |      1.41 ms |         3.11 ms |         4.18 ms |     7.67 ms |
+
+For these datasets, forced writes spend 0.82 to 13.12 ms in the two encoders.
+Reads spend 1.00 to 12.93 ms in the corresponding decoders. Automatic writes
+add another 4.86 to 11.28 ms to decide whether the filters are worthwhile. The
+fixed probe cost dominates the two smallest examples; forcing the transforms
+is therefore faster when the caller already knows that storage is the priority.

--- a/benchmarks/benchmark-mesh-filters.py
+++ b/benchmarks/benchmark-mesh-filters.py
@@ -1,0 +1,276 @@
+"""Benchmark format-version-3 mesh filters on synthetic and example meshes."""
+
+# ruff: noqa: INP001, S101, T201
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict
+from dataclasses import dataclass
+import gc
+import json
+from pathlib import Path
+import platform
+from statistics import median
+from tempfile import TemporaryDirectory
+from time import perf_counter
+from typing import TYPE_CHECKING
+from typing import Literal
+
+import numpy as np
+import pyvista as pv
+from pyvista import examples
+from vtkmodules.util.numpy_support import vtk_to_numpy
+
+import pyvista_zstd as pvzstd
+from pyvista_zstd.pyvista_zstd import _FILTER_COMPONENT_SHUFFLE
+from pyvista_zstd.pyvista_zstd import _FILTER_NONE
+from pyvista_zstd.pyvista_zstd import _FILTER_TRIANGLE_DELTA_SHUFFLE
+from pyvista_zstd.pyvista_zstd import _component_shuffle_bytes
+from pyvista_zstd.pyvista_zstd import _special_filter_beneficial
+from pyvista_zstd.pyvista_zstd import _triangle_delta_shuffle_bytes
+from pyvista_zstd.pyvista_zstd import _uncomponent_shuffle_bytes
+from pyvista_zstd.pyvista_zstd import _untriangle_delta_shuffle_bytes
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+Mode = Literal["off", "force", "auto"]
+MAX_FULL_REPEATS_CELLS = 500_000
+
+
+@dataclass(frozen=True)
+class Result:
+    """One end-to-end benchmark result."""
+
+    dataset: str
+    source: str
+    points: int
+    triangles: int
+    mode: Mode
+    file_bytes: int
+    write_seconds: float
+    read_seconds: float
+
+
+@dataclass(frozen=True)
+class TransformResult:
+    """Direct transform and probe costs for one dataset."""
+
+    dataset: str
+    point_encode_seconds: float
+    point_decode_seconds: float
+    point_probe_seconds: float
+    connectivity_encode_seconds: float
+    connectivity_decode_seconds: float
+    connectivity_probe_seconds: float
+
+
+def _median_seconds(func: Callable[[], object], repeats: int) -> float:
+    func()
+    samples = []
+    for _ in range(repeats):
+        gc.collect()
+        start = perf_counter()
+        func()
+        samples.append(perf_counter() - start)
+    return median(samples)
+
+
+def _synthetic_grid(n_side: int, *, scramble: bool = False) -> pv.PolyData:
+    """Return a smooth triangulated height field with optional cell scrambling."""
+    x, y = np.meshgrid(
+        np.linspace(-1, 1, n_side, dtype=np.float32),
+        np.linspace(-1, 1, n_side, dtype=np.float32),
+        indexing="ij",
+    )
+    z = (0.1 * np.sin(5 * x) * np.cos(7 * y)).astype(np.float32)
+    points = np.column_stack((x.ravel(), y.ravel(), z.ravel()))
+    ids = np.arange(n_side * n_side, dtype=np.int32).reshape(n_side, n_side)
+    lower_left = ids[:-1, :-1].ravel()
+    lower_right = ids[1:, :-1].ravel()
+    upper_left = ids[:-1, 1:].ravel()
+    upper_right = ids[1:, 1:].ravel()
+    triangles = np.concatenate(
+        (
+            np.column_stack((lower_left, lower_right, upper_right)),
+            np.column_stack((lower_left, upper_right, upper_left)),
+        )
+    )
+    if scramble:
+        triangles = triangles[np.random.default_rng(12).permutation(len(triangles))]
+    faces = np.empty((len(triangles), 4), dtype=np.int64)
+    faces[:, 0] = 3
+    faces[:, 1:] = triangles
+    return pv.PolyData(points, faces)
+
+
+def _synthetic_random(n_side: int) -> pv.PolyData:
+    """Return valid but incompressible points and triangle connectivity."""
+    rng = np.random.default_rng(23)
+    n_points = n_side * n_side
+    n_triangles = 2 * (n_side - 1) ** 2
+    points = rng.random((n_points, 3), dtype=np.float32)
+    triangles = rng.integers(0, n_points, size=(n_triangles, 3), dtype=np.int32)
+    faces = np.empty((n_triangles, 4), dtype=np.int64)
+    faces[:, 0] = 3
+    faces[:, 1:] = triangles
+    return pv.PolyData(points, faces)
+
+
+def _example_meshes() -> dict[str, pv.PolyData]:
+    """Load real triangle meshes published through ``pyvista.examples``."""
+    return {
+        "bunny": examples.download_bunny(),
+        "horse": examples.download_horse(),
+        "woman": examples.download_woman(),
+        "louis_louvre": examples.download_louis_louvre(),
+    }
+
+
+def _connectivity(mesh: pv.PolyData) -> np.ndarray:
+    return vtk_to_numpy(mesh.GetPolys().GetConnectivityArray())
+
+
+def _transform_benchmark(name: str, mesh: pv.PolyData, repeats: int) -> TransformResult:
+    points = np.asarray(mesh.points)
+    connectivity = _connectivity(mesh).astype(np.int32, copy=False)
+    encoded_points = _component_shuffle_bytes(points)
+    encoded_connectivity = _triangle_delta_shuffle_bytes(connectivity)
+    result = TransformResult(
+        dataset=name,
+        point_encode_seconds=_median_seconds(lambda: _component_shuffle_bytes(points), repeats),
+        point_decode_seconds=_median_seconds(
+            lambda: _uncomponent_shuffle_bytes(encoded_points, points.dtype, points.shape),
+            repeats,
+        ),
+        point_probe_seconds=_median_seconds(
+            lambda: _special_filter_beneficial(points, _FILTER_COMPONENT_SHUFFLE, _FILTER_NONE, 3),
+            repeats,
+        ),
+        connectivity_encode_seconds=_median_seconds(
+            lambda: _triangle_delta_shuffle_bytes(connectivity),
+            repeats,
+        ),
+        connectivity_decode_seconds=_median_seconds(
+            lambda: _untriangle_delta_shuffle_bytes(
+                encoded_connectivity,
+                connectivity.dtype,
+                connectivity.shape,
+            ),
+            repeats,
+        ),
+        connectivity_probe_seconds=_median_seconds(
+            lambda: _special_filter_beneficial(
+                connectivity,
+                _FILTER_TRIANGLE_DELTA_SHUFFLE,
+                _FILTER_NONE,
+                3,
+            ),
+            repeats,
+        ),
+    )
+    assert _uncomponent_shuffle_bytes(encoded_points, points.dtype, points.shape).tobytes() == points.tobytes()
+    assert (
+        _untriangle_delta_shuffle_bytes(encoded_connectivity, connectivity.dtype, connectivity.shape).tobytes()
+        == connectivity.tobytes()
+    )
+    return result
+
+
+def _end_to_end_benchmark(  # noqa: PLR0913
+    name: str,
+    source: str,
+    mesh: pv.PolyData,
+    mode: Mode,
+    output: Path,
+    repeats: int,
+) -> Result:
+    mesh_filter_setting: bool | Literal["auto"] = {"off": False, "force": True, "auto": "auto"}[mode]
+    write_seconds = _median_seconds(
+        lambda: pvzstd.write(
+            mesh,
+            output,
+            level=3,
+            n_threads=0,
+            mesh_filters=mesh_filter_setting,
+        ),
+        repeats,
+    )
+    read_seconds = _median_seconds(lambda: pvzstd.read(output, n_threads=0), repeats)
+    recovered = pvzstd.read(output, n_threads=0)
+    expected_connectivity = _connectivity(mesh).astype(np.int32, copy=False)
+    assert recovered.points.tobytes() == mesh.points.tobytes()
+    assert _connectivity(recovered).tobytes() == expected_connectivity.tobytes()
+    return Result(
+        dataset=name,
+        source=source,
+        points=mesh.n_points,
+        triangles=mesh.n_cells,
+        mode=mode,
+        file_bytes=output.stat().st_size,
+        write_seconds=write_seconds,
+        read_seconds=read_seconds,
+    )
+
+
+def main() -> None:
+    """Run the benchmark and print machine-readable JSON."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--synthetic-side", type=int, default=700)
+    parser.add_argument("--repeats", type=int, default=5)
+    parser.add_argument("--quick", action="store_true")
+    args = parser.parse_args()
+    repeats = 2 if args.quick else args.repeats
+    synthetic_side = 300 if args.quick else args.synthetic_side
+    meshes = {
+        "synthetic_ordered": ("synthetic", _synthetic_grid(synthetic_side)),
+        "synthetic_scrambled": ("synthetic", _synthetic_grid(synthetic_side, scramble=True)),
+        "synthetic_random": ("synthetic", _synthetic_random(synthetic_side)),
+        **{name: ("pyvista.examples", mesh) for name, mesh in _example_meshes().items()},
+    }
+    results = []
+    transforms = []
+    with TemporaryDirectory(prefix="pyvista-zstd-mesh-filter-benchmark-") as tmp:
+        tmp_path = Path(tmp)
+        for name, (source, mesh) in meshes.items():
+            if not mesh.is_all_triangles:
+                msg = f"{name} is not an all-triangle mesh"
+                raise ValueError(msg)
+            dataset_repeats = repeats if mesh.n_cells < MAX_FULL_REPEATS_CELLS else max(2, repeats // 2)
+            transforms.append(_transform_benchmark(name, mesh, dataset_repeats))
+            results.extend(
+                [
+                    _end_to_end_benchmark(
+                        name,
+                        source,
+                        mesh,
+                        mode,
+                        tmp_path / f"{name}-{mode}.pv",
+                        dataset_repeats,
+                    )
+                    for mode in ("off", "force", "auto")
+                ]
+            )
+    print(
+        json.dumps(
+            {
+                "platform": platform.platform(),
+                "python_version": platform.python_version(),
+                "pyvista_version": pv.__version__,
+                "vtk_version": pv.vtk_version_info,
+                "numpy_version": np.__version__,
+                "compression_level": 3,
+                "n_threads": 0,
+                "repeats": repeats,
+                "synthetic_side": synthetic_side,
+                "results": [asdict(result) for result in results],
+                "transforms": [asdict(result) for result in transforms],
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pyvista_zstd/pyvista_zstd.py
+++ b/src/pyvista_zstd/pyvista_zstd.py
@@ -140,6 +140,12 @@ MeshFilterSpec = Literal["auto", True, False]
 # arrays are decided from a representative contiguous middle sample, keeping the
 # probe cheap on big payloads where shuffle reliably wins.
 _SHUFFLE_PROBE_BYTES = 1 << 20  # 1 MiB
+# Mesh-filter probes compare layout rather than final compression ratio. A fast
+# zstd level preserves that signal while avoiding a second level-3 compression
+# pass over as much as 2 MiB per mesh.
+_MESH_FILTER_PROBE_LEVEL = -5
+_MESH_FILTER_MIN_BYTES = 4 << 10
+_FILTER_TRANSFORM_CHUNK_BYTES = 1 << 20
 
 
 def _auto_shuffle_beneficial(arr: np.ndarray, level: int) -> bool:
@@ -185,7 +191,14 @@ def _shuffle_bytes(arr: np.ndarray) -> np.ndarray:
 def _unshuffle_bytes(buf: memoryview | bytes, itemsize: int) -> np.ndarray:
     """Invert :func:`_shuffle_bytes`, returning a contiguous uint8 array."""
     flat = np.frombuffer(buf, dtype=np.uint8)
-    return flat.reshape(itemsize, -1).T.reshape(-1)
+    planes = flat.reshape(itemsize, -1)
+    output = np.empty(flat.size, dtype=np.uint8).reshape(-1, itemsize)
+    rows_per_chunk = max(1, _FILTER_TRANSFORM_CHUNK_BYTES // itemsize)
+    for start in range(0, len(output), rows_per_chunk):
+        end = min(start + rows_per_chunk, len(output))
+        for index in range(itemsize):
+            output[start:end, index] = planes[index, start:end]
+    return output.reshape(-1)
 
 
 def _component_shuffle_bytes(arr: np.ndarray) -> np.ndarray:
@@ -193,7 +206,16 @@ def _component_shuffle_bytes(arr: np.ndarray) -> np.ndarray:
     if arr.ndim != _TUPLE_NDIM or arr.shape[1] < _MIN_COMPONENTS:
         msg = "Component shuffle requires a two-dimensional tuple array."
         raise ValueError(msg)
-    return _shuffle_bytes(np.ascontiguousarray(arr.T))
+    raw = np.ascontiguousarray(arr).view(np.uint8).reshape(arr.shape[0], arr.shape[1], arr.dtype.itemsize)
+    output = np.empty(raw.size, dtype=np.uint8).reshape(arr.dtype.itemsize, arr.shape[1], arr.shape[0])
+    bytes_per_row = arr.shape[1] * arr.dtype.itemsize
+    rows_per_chunk = max(1, _FILTER_TRANSFORM_CHUNK_BYTES // bytes_per_row)
+    for start in range(0, arr.shape[0], rows_per_chunk):
+        end = min(start + rows_per_chunk, arr.shape[0])
+        for byte_index in range(arr.dtype.itemsize):
+            for component_index in range(arr.shape[1]):
+                output[byte_index, component_index, start:end] = raw[start:end, component_index, byte_index]
+    return output.reshape(-1)
 
 
 def _uncomponent_shuffle_bytes(
@@ -205,8 +227,17 @@ def _uncomponent_shuffle_bytes(
     if len(shape) != _TUPLE_NDIM or shape[1] < _MIN_COMPONENTS:
         msg = f"Invalid component-shuffle shape {shape}."
         raise ValueError(msg)
-    planar = _unshuffle_bytes(buf, dtype.itemsize).view(dtype).reshape(shape[1], shape[0])
-    return np.ascontiguousarray(planar.T)
+    flat = np.frombuffer(buf, dtype=np.uint8)
+    planes = flat.reshape(dtype.itemsize, shape[1], shape[0])
+    output = np.empty((shape[0], shape[1], dtype.itemsize), dtype=np.uint8)
+    bytes_per_row = shape[1] * dtype.itemsize
+    rows_per_chunk = max(1, _FILTER_TRANSFORM_CHUNK_BYTES // bytes_per_row)
+    for start in range(0, shape[0], rows_per_chunk):
+        end = min(start + rows_per_chunk, shape[0])
+        for byte_index in range(dtype.itemsize):
+            for component_index in range(shape[1]):
+                output[start:end, component_index, byte_index] = planes[byte_index, component_index, start:end]
+    return output.view(dtype).reshape(shape)
 
 
 def _triangle_delta_shuffle_bytes(arr: np.ndarray) -> np.ndarray:
@@ -215,10 +246,23 @@ def _triangle_delta_shuffle_bytes(arr: np.ndarray) -> np.ndarray:
         msg = "Triangle delta shuffle requires a nonempty integer array whose length is divisible by 3."
         raise ValueError(msg)
     triangles = np.ascontiguousarray(arr).reshape(-1, _TRIANGLE_SIZE)
-    deltas = np.empty_like(triangles)
-    deltas[0] = triangles[0]
-    np.subtract(triangles[1:], triangles[:-1], out=deltas[1:])
-    return _shuffle_bytes(deltas)
+    output = np.empty(arr.nbytes, dtype=np.uint8).reshape(arr.dtype.itemsize, arr.size)
+    rows_per_chunk = max(1, _FILTER_TRANSFORM_CHUNK_BYTES // (_TRIANGLE_SIZE * arr.dtype.itemsize))
+    for start in range(0, len(triangles), rows_per_chunk):
+        end = min(start + rows_per_chunk, len(triangles))
+        deltas = np.empty_like(triangles[start:end])
+        if start == 0:
+            deltas[0] = triangles[0]
+            if end > 1:
+                np.subtract(triangles[1:end], triangles[: end - 1], out=deltas[1:])
+        else:
+            np.subtract(triangles[start:end], triangles[start - 1 : end - 1], out=deltas)
+        raw = deltas.reshape(-1).view(np.uint8).reshape(-1, arr.dtype.itemsize)
+        element_start = start * _TRIANGLE_SIZE
+        element_end = end * _TRIANGLE_SIZE
+        for byte_index in range(arr.dtype.itemsize):
+            output[byte_index, element_start:element_end] = raw[:, byte_index]
+    return output.reshape(-1)
 
 
 def _untriangle_delta_shuffle_bytes(
@@ -232,7 +276,7 @@ def _untriangle_delta_shuffle_bytes(
         msg = f"Invalid triangle-delta array with dtype {dtype} and shape {shape}."
         raise ValueError(msg)
     deltas = _unshuffle_bytes(buf, dtype.itemsize).view(dtype).reshape(-1, _TRIANGLE_SIZE)
-    np.cumsum(deltas, axis=0, dtype=dtype, out=deltas)
+    np.add.accumulate(deltas, axis=0, dtype=dtype, out=deltas)
     return deltas.reshape(shape)
 
 
@@ -270,7 +314,7 @@ def _special_filter_beneficial(
     sample = _sample_rows(arr, row_width)
     if specialized_filter == _FILTER_TRIANGLE_DELTA_SHUFFLE:
         sample = sample.reshape(-1)
-    cctx = zstd.ZstdCompressor(level=level)
+    cctx = zstd.ZstdCompressor(level=min(level, _MESH_FILTER_PROBE_LEVEL))
     specialized_size = len(cctx.compress(_filtered_bytes(sample, specialized_filter)))
     baseline_size = len(cctx.compress(_filtered_bytes(sample, baseline_filter)))
     return specialized_size < baseline_size
@@ -876,6 +920,8 @@ class Writer:
             return baseline
         if mesh_filters is True:
             return specialized
+        if arr.nbytes < _MESH_FILTER_MIN_BYTES:
+            return baseline
         if _special_filter_beneficial(arr, specialized, baseline, level):
             return specialized
         return baseline

--- a/src/pyvista_zstd/pyvista_zstd.py
+++ b/src/pyvista_zstd/pyvista_zstd.py
@@ -47,17 +47,17 @@ if TYPE_CHECKING:  # pragma: no cover
     from pyvista.core.dataset import DataSet
 
 # Highest on-disk format version this library can READ. Version 1 added the
-# optional byte-shuffle pre-filter (see ``_FILTER_*`` below), and version 2
-# adds fixed-width cell arrays that store their cell size in dataset metadata
-# instead of writing a redundant offsets frame. A reader refuses any file
-# whose ``file_version`` exceeds this value.
-FILE_VERSION = 2
+# optional byte-shuffle pre-filter (see ``_FILTER_*`` below), version 2 added
+# fixed-width cell arrays, and version 3 adds lossless mesh-specific filters.
+# A reader refuses any file whose ``file_version`` exceeds this value.
+FILE_VERSION = 3
 # Version stamped on files that use neither byte filters nor fixed-width cell
 # arrays. Such files stay byte-identical to the legacy format and remain
 # readable by older releases.
 FILE_VERSION_UNFILTERED = 0
 FILE_VERSION_SHUFFLE = 1
 FILE_VERSION_FIXED_WIDTH_CELLS = 2
+FILE_VERSION_MESH_FILTERS = 3
 FILE_VERSION_KEY = "FILE_VERSION"
 DS_TYPE_KEY = "ds_type"
 POINT_DATA_SUFFIX = "__point_data"
@@ -121,6 +121,11 @@ VTK_DOUBLE = 11
 # layout byte-identical to the legacy format.
 _FILTER_NONE = 0
 _FILTER_SHUFFLE = 1
+_FILTER_COMPONENT_SHUFFLE = 2
+_FILTER_TRIANGLE_DELTA_SHUFFLE = 3
+_TUPLE_NDIM = 2
+_MIN_COMPONENTS = 2
+_TRIANGLE_SIZE = 3
 
 # The byte-shuffle pre-filter is opt-in (disabled by default).  ``shuffle="auto"``
 # considers only multibyte floating-point arrays -- the payloads that can
@@ -128,6 +133,7 @@ _FILTER_SHUFFLE = 1
 # it actually shrinks the data, so ``auto`` never inflates a file (shuffling
 # already-regular data, e.g. small coordinate ramps, can otherwise hurt).
 ShuffleSpec = Literal["auto", True, False]
+MeshFilterSpec = Literal["auto", True, False]
 
 # Sample budget for the ``auto`` probe.  Arrays at or below this many bytes are
 # evaluated exactly (the whole array is trial-compressed both ways); larger
@@ -180,6 +186,94 @@ def _unshuffle_bytes(buf: memoryview | bytes, itemsize: int) -> np.ndarray:
     """Invert :func:`_shuffle_bytes`, returning a contiguous uint8 array."""
     flat = np.frombuffer(buf, dtype=np.uint8)
     return flat.reshape(itemsize, -1).T.reshape(-1)
+
+
+def _component_shuffle_bytes(arr: np.ndarray) -> np.ndarray:
+    """Store tuple components in separate byte-shuffled planes."""
+    if arr.ndim != _TUPLE_NDIM or arr.shape[1] < _MIN_COMPONENTS:
+        msg = "Component shuffle requires a two-dimensional tuple array."
+        raise ValueError(msg)
+    return _shuffle_bytes(np.ascontiguousarray(arr.T))
+
+
+def _uncomponent_shuffle_bytes(
+    buf: memoryview | bytes,
+    dtype: np.dtype[Any],
+    shape: tuple[int, ...],
+) -> np.ndarray:
+    """Invert :func:`_component_shuffle_bytes`."""
+    if len(shape) != _TUPLE_NDIM or shape[1] < _MIN_COMPONENTS:
+        msg = f"Invalid component-shuffle shape {shape}."
+        raise ValueError(msg)
+    planar = _unshuffle_bytes(buf, dtype.itemsize).view(dtype).reshape(shape[1], shape[0])
+    return np.ascontiguousarray(planar.T)
+
+
+def _triangle_delta_shuffle_bytes(arr: np.ndarray) -> np.ndarray:
+    """Delta consecutive triangle tuples, then byte-shuffle the result."""
+    if arr.dtype.kind not in ("i", "u") or arr.size == 0 or arr.size % _TRIANGLE_SIZE:
+        msg = "Triangle delta shuffle requires a nonempty integer array whose length is divisible by 3."
+        raise ValueError(msg)
+    triangles = np.ascontiguousarray(arr).reshape(-1, _TRIANGLE_SIZE)
+    deltas = np.empty_like(triangles)
+    deltas[0] = triangles[0]
+    np.subtract(triangles[1:], triangles[:-1], out=deltas[1:])
+    return _shuffle_bytes(deltas)
+
+
+def _untriangle_delta_shuffle_bytes(
+    buf: memoryview | bytes,
+    dtype: np.dtype[Any],
+    shape: tuple[int, ...],
+) -> np.ndarray:
+    """Invert :func:`_triangle_delta_shuffle_bytes`."""
+    size = int(np.prod(shape, dtype=np.int64))
+    if dtype.kind not in ("i", "u") or size == 0 or size % _TRIANGLE_SIZE:
+        msg = f"Invalid triangle-delta array with dtype {dtype} and shape {shape}."
+        raise ValueError(msg)
+    deltas = _unshuffle_bytes(buf, dtype.itemsize).view(dtype).reshape(-1, _TRIANGLE_SIZE)
+    np.cumsum(deltas, axis=0, dtype=dtype, out=deltas)
+    return deltas.reshape(shape)
+
+
+def _filtered_bytes(arr: np.ndarray, filter_id: int) -> np.ndarray:
+    """Return the bytes represented by a per-array filter."""
+    if filter_id == _FILTER_NONE:
+        return np.ascontiguousarray(arr).reshape(-1).view(np.uint8)
+    if filter_id == _FILTER_SHUFFLE:
+        return _shuffle_bytes(arr)
+    if filter_id == _FILTER_COMPONENT_SHUFFLE:
+        return _component_shuffle_bytes(arr)
+    if filter_id == _FILTER_TRIANGLE_DELTA_SHUFFLE:
+        return _triangle_delta_shuffle_bytes(arr)
+    msg = f"Unsupported per-array filter id {filter_id}."
+    raise ValueError(msg)
+
+
+def _sample_rows(arr: np.ndarray, row_width: int) -> np.ndarray:
+    """Return a centered sample containing complete fixed-width rows."""
+    rows = np.ascontiguousarray(arr).reshape(-1, row_width)
+    bytes_per_row = row_width * arr.dtype.itemsize
+    n_sample = min(len(rows), max(1, _SHUFFLE_PROBE_BYTES // bytes_per_row))
+    start = (len(rows) - n_sample) // 2
+    return rows[start : start + n_sample]
+
+
+def _special_filter_beneficial(
+    arr: np.ndarray,
+    specialized_filter: int,
+    baseline_filter: int,
+    level: int,
+) -> bool:
+    """Compare a mesh-specific filter with the selected baseline on one sample."""
+    row_width = _TRIANGLE_SIZE if specialized_filter == _FILTER_TRIANGLE_DELTA_SHUFFLE else arr.shape[1]
+    sample = _sample_rows(arr, row_width)
+    if specialized_filter == _FILTER_TRIANGLE_DELTA_SHUFFLE:
+        sample = sample.reshape(-1)
+    cctx = zstd.ZstdCompressor(level=level)
+    specialized_size = len(cctx.compress(_filtered_bytes(sample, specialized_filter)))
+    baseline_size = len(cctx.compress(_filtered_bytes(sample, baseline_filter)))
+    return specialized_size < baseline_size
 
 
 @dataclass(slots=True, frozen=True)
@@ -540,6 +634,7 @@ def write(  # noqa: PLR0913
     level: int = 3,
     n_threads: int | None = None,
     shuffle: ShuffleSpec = False,
+    mesh_filters: MeshFilterSpec = "auto",
 ) -> None:
     """
     Compress a PyVista or VTK dataset.
@@ -589,6 +684,14 @@ def write(  # noqa: PLR0913
         use the filter are written at format version 1 and can only be read by
         this release or newer; unfiltered files (the default) stay backward
         compatible unless they use fixed-width cell arrays.
+    mesh_filters : {"auto", True, False}, default: "auto"
+        Apply lossless mesh-specific transforms to explicit point coordinates
+        and homogeneous triangle connectivity. Point tuples are stored in
+        component-major byte planes. Triangle connectivity is differenced
+        between consecutive cells and then byte-shuffled. ``"auto"`` uses a
+        trial compression and keeps each transform only when it beats the
+        selected generic representation. ``True`` forces the transforms on
+        eligible arrays, and ``False`` disables them.
 
     Notes
     -----
@@ -596,6 +699,7 @@ def write(  # noqa: PLR0913
     without their redundant offsets array. Their common width is recorded in
     dataset metadata and VTK reconstructs the offsets when the file is read.
     Files using this encoding are written at format version 2.
+    Files using a mesh-specific transform are written at format version 3.
 
     """
     writer = Writer(ds, filename)
@@ -607,6 +711,7 @@ def write(  # noqa: PLR0913
         level=level,
         n_threads=n_threads,
         shuffle=shuffle,
+        mesh_filters=mesh_filters,
     )
 
 
@@ -647,11 +752,33 @@ class Writer:
         self._arrays: dict[str, NDArray[Any]] = {}
         self._ds = pv.wrap(ds)
         self._uses_fixed_width_cells = False
+        self._point_names: set[str] = set()
+        self._triangle_connectivity_names: set[str] = set()
 
         # used to hold a reference to the dataset. This is necessary for
         # multiblocks to avoid having them collected and getting duplicate
         # memory addresses
         self._refs: list[DataSet | MultiBlock] = []
+
+    def _register_mesh_filter_candidates(
+        self,
+        ds: DataSet,
+        ds_id: str,
+        fixed_cell_sizes: dict[str, int],
+    ) -> None:
+        """Record topology arrays eligible for mesh-specific filters."""
+        point_name = f"{ds_id}{POINTS_KEY}"
+        if point_name in self._arrays:
+            self._point_names.add(point_name)
+        if isinstance(ds, PolyData) and fixed_cell_sizes.get(POLYS) == _TRIANGLE_SIZE:
+            self._triangle_connectivity_names.add(f"{ds_id}{POLYS}{CONNECTIVITY_SUFFIX}")
+        elif (
+            isinstance(ds, UnstructuredGrid)
+            and fixed_cell_sizes.get(CELLS) == _TRIANGLE_SIZE
+            and ds.n_cells > 0
+            and np.all(ds.celltypes == pv.CellType.TRIANGLE)
+        ):
+            self._triangle_connectivity_names.add(f"{ds_id}{CELLS}{CONNECTIVITY_SUFFIX}")
 
     def _add_ds_arrays(self, ds: DataSet, *, force_int32: bool) -> None:  # noqa: C901, PLR0912
         """Extract dataset data as arrays."""
@@ -721,8 +848,39 @@ class Writer:
         ds_meta = DataSetMetadata.from_dataset(ds, point_info, cell_info, field_info, fixed_cell_sizes)
         self._arrays[f"{ds_id}{DS_METADATA_KEY}"] = ds_meta.to_array()
         self._uses_fixed_width_cells = self._uses_fixed_width_cells or bool(fixed_cell_sizes)
+        self._register_mesh_filter_candidates(ds, ds_id, fixed_cell_sizes)
 
-    def write(
+    def _resolve_filter(
+        self,
+        name: str,
+        arr: np.ndarray,
+        *,
+        shuffle: ShuffleSpec,
+        mesh_filters: MeshFilterSpec,
+        level: int,
+    ) -> int:
+        """Choose the smallest requested lossless representation for an array."""
+        baseline = _FILTER_SHUFFLE if _resolve_shuffle(arr, shuffle, level) else _FILTER_NONE
+        specialized = _FILTER_NONE
+        if (
+            name in self._point_names
+            and arr.ndim == _TUPLE_NDIM
+            and arr.shape[1] >= _MIN_COMPONENTS
+            and arr.dtype.itemsize > 1
+        ):
+            specialized = _FILTER_COMPONENT_SHUFFLE
+        elif name in self._triangle_connectivity_names:
+            specialized = _FILTER_TRIANGLE_DELTA_SHUFFLE
+
+        if specialized == _FILTER_NONE or mesh_filters is False:
+            return baseline
+        if mesh_filters is True:
+            return specialized
+        if _special_filter_beneficial(arr, specialized, baseline, level):
+            return specialized
+        return baseline
+
+    def write(  # noqa: PLR0913
         self,
         *,
         progress_bar: bool = False,
@@ -730,6 +888,7 @@ class Writer:
         level: int = 3,
         n_threads: int | None = None,
         shuffle: ShuffleSpec = False,
+        mesh_filters: MeshFilterSpec = "auto",
     ) -> None:
         """Write the dataset."""
         if self._filename.suffix == LEGACY_FILE_SUFFIX:
@@ -755,13 +914,20 @@ class Writer:
         # stays at FILE_VERSION_UNFILTERED and remains readable by older
         # releases.
         filters = {
-            name: (_FILTER_SHUFFLE if _resolve_shuffle(arr, shuffle, level) else _FILTER_NONE)
+            name: self._resolve_filter(
+                name,
+                arr,
+                shuffle=shuffle,
+                mesh_filters=mesh_filters,
+                level=level,
+            )
             for name, arr in self._arrays.items()
         }
-        any_filtered = any(f != _FILTER_NONE for f in filters.values())
-        if self._uses_fixed_width_cells:
+        if any(f in (_FILTER_COMPONENT_SHUFFLE, _FILTER_TRIANGLE_DELTA_SHUFFLE) for f in filters.values()):
+            version = FILE_VERSION_MESH_FILTERS
+        elif self._uses_fixed_width_cells:
             version = FILE_VERSION_FIXED_WIDTH_CELLS
-        elif any_filtered:
+        elif any(f != _FILTER_NONE for f in filters.values()):
             version = FILE_VERSION_SHUFFLE
         else:
             version = FILE_VERSION_UNFILTERED
@@ -776,12 +942,12 @@ class Writer:
         filters[FILE_METADATA_KEY] = _FILTER_NONE  # JSON blob: never shuffled
 
         # data to compress must include array metadata and the array.  A
-        # shuffled array yields a fresh byte-plane buffer; otherwise the raw
-        # bytes are a zero-copy uint8 view.
-        data: list[bytes] = []
+        # Filtered arrays yield fresh buffers; otherwise the raw bytes are a
+        # zero-copy uint8 view.
+        data: list[Any] = []
         for name, arr in self._arrays.items():
             filter_id = filters[name]
-            arr_bytes = _shuffle_bytes(arr).data if filter_id == _FILTER_SHUFFLE else arr.ravel().view(np.uint8).data
+            arr_bytes = _filtered_bytes(arr, filter_id).data
             data.extend([_pack_array_metadata(name, arr, filter_id), arr_bytes])
 
         # Compress multiple pieces of data as a single function call to minimize overhead
@@ -844,6 +1010,10 @@ def _reconstruct_array(
     elif filter_id == _FILTER_SHUFFLE:
         # Invert the byte-plane split, then view as the original dtype.
         data = _unshuffle_bytes(data_buf, dtype.itemsize).view(dtype).reshape(shape)
+    elif filter_id == _FILTER_COMPONENT_SHUFFLE:
+        data = _uncomponent_shuffle_bytes(data_buf, dtype, shape)
+    elif filter_id == _FILTER_TRIANGLE_DELTA_SHUFFLE:
+        data = _untriangle_delta_shuffle_bytes(data_buf, dtype, shape)
     else:
         # An unknown filter id means this build cannot reverse the on-disk
         # transform; reading the bytes as-is would corrupt the array, so fail.
@@ -1183,7 +1353,7 @@ class Reader:
     >>> reader
     pyvista_zstd.Reader (0x7f1ed1496c00)
       File:               sphere.pv
-      File Version:       0
+      File Version:       3
       Compression:        zstandard
       Compression Level:  3
       Dataset Type:       PolyData

--- a/tests/test_fixed_width_cells.py
+++ b/tests/test_fixed_width_cells.py
@@ -33,7 +33,7 @@ def _frame_name(reader: pz.Reader, name: str, suffix: str) -> str:
 def test_homogeneous_polydata_omits_offsets(polydata: pv.PolyData, tmp_path: Path) -> None:
     """Triangle-only PolyData stores its width in metadata, not an offsets frame."""
     path = tmp_path / "triangles.pv"
-    pz.write(polydata, path)
+    pz.write(polydata, path, mesh_filters=False)
 
     reader = pz.Reader(path)
     frame_names = reader._metadata.frame_names  # noqa: SLF001
@@ -100,7 +100,7 @@ def test_mixed_width_cells_keep_offsets(tmp_path: Path) -> None:
 def test_fixed_width_and_shuffle_use_version_2(polydata: pv.PolyData, tmp_path: Path) -> None:
     """Format version 2 covers fixed-width topology combined with byte shuffle."""
     path = tmp_path / "fixed-shuffled.pv"
-    pz.write(polydata, path, shuffle=True)
+    pz.write(polydata, path, shuffle=True, mesh_filters=False)
     reader = pz.Reader(path)
     assert reader._metadata.file_version == FILE_VERSION_FIXED_WIDTH_CELLS  # noqa: SLF001
     assert reader.read() == polydata
@@ -109,7 +109,7 @@ def test_fixed_width_and_shuffle_use_version_2(polydata: pv.PolyData, tmp_path: 
 def test_append_preserves_fixed_width_metadata(polydata: pv.PolyData, tmp_path: Path) -> None:
     """Appending field data keeps the fixed-width topology metadata intact."""
     path = tmp_path / "append.pv"
-    pz.write(polydata, path)
+    pz.write(polydata, path, mesh_filters=False)
     append_arrays(path, {"run_id": np.array([7], dtype=np.int32)})
 
     reader = pz.Reader(path)

--- a/tests/test_mesh_filters.py
+++ b/tests/test_mesh_filters.py
@@ -1,0 +1,182 @@
+"""Tests for lossless mesh-specific filters (format version 3)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+import pyvista as pv
+from vtkmodules.util.numpy_support import vtk_to_numpy
+
+import pyvista_zstd as pz
+from pyvista_zstd import pyvista_zstd as _pz_mod
+from pyvista_zstd.pyvista_zstd import _FILTER_COMPONENT_SHUFFLE
+from pyvista_zstd.pyvista_zstd import _FILTER_NONE
+from pyvista_zstd.pyvista_zstd import _FILTER_TRIANGLE_DELTA_SHUFFLE
+from pyvista_zstd.pyvista_zstd import CELLS
+from pyvista_zstd.pyvista_zstd import CONNECTIVITY_SUFFIX
+from pyvista_zstd.pyvista_zstd import FILE_VERSION_FIXED_WIDTH_CELLS
+from pyvista_zstd.pyvista_zstd import FILE_VERSION_MESH_FILTERS
+from pyvista_zstd.pyvista_zstd import FILE_VERSION_UNFILTERED
+from pyvista_zstd.pyvista_zstd import POINTS_KEY
+from pyvista_zstd.pyvista_zstd import POLYS
+from pyvista_zstd.pyvista_zstd import Writer
+from pyvista_zstd.pyvista_zstd import _component_shuffle_bytes
+from pyvista_zstd.pyvista_zstd import _special_filter_beneficial
+from pyvista_zstd.pyvista_zstd import _triangle_delta_shuffle_bytes
+from pyvista_zstd.pyvista_zstd import _uncomponent_shuffle_bytes
+from pyvista_zstd.pyvista_zstd import _untriangle_delta_shuffle_bytes
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_component_shuffle_roundtrip_is_bit_exact(dtype: type[np.floating]) -> None:
+    """Component-planar byte shuffle preserves every floating-point bit."""
+    bits = np.arange(3072 * np.dtype(dtype).itemsize, dtype=np.uint8)
+    points = bits.view(dtype).reshape(-1, 3)
+    encoded = _component_shuffle_bytes(points)
+    recovered = _uncomponent_shuffle_bytes(encoded, points.dtype, points.shape)
+    assert recovered.tobytes() == points.tobytes()
+
+
+@pytest.mark.parametrize("dtype", [np.int32, np.int64, np.uint32, np.uint64])
+def test_triangle_delta_shuffle_roundtrip_is_bit_exact(dtype: type[np.integer]) -> None:
+    """Same-dtype modular deltas preserve signed and unsigned connectivity."""
+    info = np.iinfo(dtype)
+    triangles = np.array(
+        [[0, 1, 2], [9, 4, 7], [info.max, 0, info.min], [3, 2, 1]],
+        dtype=dtype,
+    ).reshape(-1)
+    encoded = _triangle_delta_shuffle_bytes(triangles)
+    recovered = _untriangle_delta_shuffle_bytes(encoded, triangles.dtype, triangles.shape)
+    assert recovered.tobytes() == triangles.tobytes()
+
+
+def _writer_filters(mesh: pv.DataSet, path: Path, *, automatic: bool = False) -> tuple[Writer, dict[str, int]]:
+    writer = Writer(mesh, path)
+    writer._add_ds_arrays(mesh, force_int32=True)  # noqa: SLF001
+    filters = {
+        name: writer._resolve_filter(  # noqa: SLF001
+            name,
+            arr,
+            shuffle=False,
+            mesh_filters="auto" if automatic else True,
+            level=3,
+        )
+        for name, arr in writer._arrays.items()  # noqa: SLF001
+    }
+    return writer, filters
+
+
+def test_triangle_polydata_uses_both_mesh_filters(polydata: pv.PolyData, tmp_path: Path) -> None:
+    """Point coordinates and triangle connectivity select their dedicated filters."""
+    writer, filters = _writer_filters(polydata, tmp_path / "unused.pv", automatic=True)
+    ds_id = next(iter(writer._point_names))[:16]  # noqa: SLF001
+    assert filters[f"{ds_id}{POINTS_KEY}"] == _FILTER_COMPONENT_SHUFFLE
+    assert filters[f"{ds_id}{POLYS}{CONNECTIVITY_SUFFIX}"] == _FILTER_TRIANGLE_DELTA_SHUFFLE
+
+
+def test_default_triangle_roundtrip_uses_version_3_and_is_smaller(polydata: pv.PolyData, tmp_path: Path) -> None:
+    """Automatic mesh filters round-trip and beat fixed-width-only storage."""
+    optimized = tmp_path / "optimized.pv"
+    baseline = tmp_path / "baseline.pv"
+    pz.write(polydata, optimized)
+    pz.write(polydata, baseline, mesh_filters=False)
+
+    result = pz.read(optimized)
+    assert result == polydata
+    assert result.points.tobytes() == polydata.points.tobytes()
+    result_connectivity = vtk_to_numpy(result.GetPolys().GetConnectivityArray())
+    source_connectivity = vtk_to_numpy(polydata.GetPolys().GetConnectivityArray()).astype(np.int32)
+    assert result_connectivity.tobytes() == source_connectivity.tobytes()
+    assert pz.Reader(optimized)._metadata.file_version == FILE_VERSION_MESH_FILTERS  # noqa: SLF001
+    assert pz.Reader(baseline)._metadata.file_version == FILE_VERSION_FIXED_WIDTH_CELLS  # noqa: SLF001
+    assert optimized.stat().st_size < baseline.stat().st_size
+
+
+def test_mesh_filters_false_preserves_version_2(polydata: pv.PolyData, tmp_path: Path) -> None:
+    """Callers can retain the fixed-width-only format when compatibility requires it."""
+    path = tmp_path / "version2.pv"
+    pz.write(polydata, path, mesh_filters=False)
+    assert pz.Reader(path)._metadata.file_version == FILE_VERSION_FIXED_WIDTH_CELLS  # noqa: SLF001
+    assert pz.read(path) == polydata
+
+
+def test_auto_skips_mesh_filters_for_incompressible_samples(tmp_path: Path) -> None:
+    """Automatic selection falls back when transformed bytes are not smaller."""
+    rng = np.random.default_rng(4)
+    points = rng.integers(0, 256, size=(20000, 12), dtype=np.uint8).view(np.float32)
+    triangles = rng.integers(0, 2**32, size=60000, dtype=np.uint32)
+    assert not _special_filter_beneficial(points, _FILTER_COMPONENT_SHUFFLE, _FILTER_NONE, 3)
+    assert not _special_filter_beneficial(triangles, _FILTER_TRIANGLE_DELTA_SHUFFLE, _FILTER_NONE, 3)
+
+    path = tmp_path / "incompressible.pv"
+    pointset = pv.PointSet(points)
+    pz.write(pointset, path)
+    assert pz.Reader(path)._metadata.file_version == FILE_VERSION_UNFILTERED  # noqa: SLF001
+    assert pz.read(path).points.tobytes() == pointset.points.tobytes()
+
+
+def test_all_triangle_ugrid_uses_triangle_filter(tmp_path: Path) -> None:
+    """The connectivity transform also applies to all-triangle unstructured grids."""
+    points = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0]], dtype=np.float32)
+    cells = np.array([3, 0, 1, 2, 3, 1, 3, 2])
+    types = np.full(2, pv.CellType.TRIANGLE, dtype=np.uint8)
+    grid = pv.UnstructuredGrid(cells, types, points)
+    writer, filters = _writer_filters(grid, tmp_path / "unused.pv")
+    ds_id = next(iter(writer._point_names))[:16]  # noqa: SLF001
+    assert filters[f"{ds_id}{CELLS}{CONNECTIVITY_SUFFIX}"] == _FILTER_TRIANGLE_DELTA_SHUFFLE
+
+    path = tmp_path / "triangles.pv"
+    pz.write(grid, path, mesh_filters=True)
+    result = pz.read(path)
+    assert result == grid
+    assert vtk_to_numpy(result.GetCells().GetConnectivityArray()).dtype == np.int32
+
+
+def test_equal_width_mixed_types_do_not_use_triangle_filter(tmp_path: Path) -> None:
+    """Triplet width alone does not imply that every unstructured cell is a triangle."""
+    points = np.array(
+        [[0, 0, 0], [1, 0, 0], [0, 1, 0], [2, 0, 0], [3, 0, 0], [2, 1, 0]],
+        dtype=np.float32,
+    )
+    cells = np.array([3, 0, 1, 2, 3, 3, 4, 5])
+    types = np.array([pv.CellType.TRIANGLE, pv.CellType.POLY_LINE], dtype=np.uint8)
+    grid = pv.UnstructuredGrid(cells, types, points)
+    writer, filters = _writer_filters(grid, tmp_path / "unused.pv")
+    ds_id = next(iter(writer._point_names))[:16]  # noqa: SLF001
+    assert filters[f"{ds_id}{CELLS}{CONNECTIVITY_SUFFIX}"] == _FILTER_NONE
+
+
+@pytest.mark.parametrize(
+    ("dtype", "shape", "message"),
+    [(np.float32, (6,), "Invalid triangle-delta"), (np.int32, (5,), "Invalid triangle-delta")],
+)
+def test_triangle_delta_decode_rejects_invalid_metadata(dtype: type, shape: tuple[int, ...], message: str) -> None:
+    """Malformed triangle metadata fails instead of returning corrupt connectivity."""
+    buf = np.zeros(24, dtype=np.uint8)
+    with pytest.raises(ValueError, match=message):
+        _untriangle_delta_shuffle_bytes(buf, np.dtype(dtype), shape)
+
+
+def test_component_decode_rejects_invalid_metadata() -> None:
+    """A component filter cannot be applied to a scalar-shaped frame."""
+    with pytest.raises(ValueError, match="Invalid component-shuffle shape"):
+        _uncomponent_shuffle_bytes(b"", np.dtype(np.float32), (3,))
+
+
+def test_future_mesh_filter_version_is_rejected(
+    polydata: pv.PolyData,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An older reader rejects a file stamped with a newer mesh-filter format."""
+    path = tmp_path / "future.pv"
+    monkeypatch.setattr(_pz_mod, "FILE_VERSION_MESH_FILTERS", pz.FILE_VERSION + 1)
+    pz.write(polydata, path, mesh_filters=True)
+    monkeypatch.undo()
+    with pytest.raises(ValueError, match="newer than the version supported"):
+        pz.read(path)

--- a/tests/test_mesh_filters.py
+++ b/tests/test_mesh_filters.py
@@ -23,6 +23,7 @@ from pyvista_zstd.pyvista_zstd import POINTS_KEY
 from pyvista_zstd.pyvista_zstd import POLYS
 from pyvista_zstd.pyvista_zstd import Writer
 from pyvista_zstd.pyvista_zstd import _component_shuffle_bytes
+from pyvista_zstd.pyvista_zstd import _shuffle_bytes
 from pyvista_zstd.pyvista_zstd import _special_filter_beneficial
 from pyvista_zstd.pyvista_zstd import _triangle_delta_shuffle_bytes
 from pyvista_zstd.pyvista_zstd import _uncomponent_shuffle_bytes
@@ -33,18 +34,28 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
-def test_component_shuffle_roundtrip_is_bit_exact(dtype: type[np.floating]) -> None:
+def test_component_shuffle_roundtrip_is_bit_exact(
+    dtype: type[np.floating],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Component-planar byte shuffle preserves every floating-point bit."""
+    monkeypatch.setattr(_pz_mod, "_FILTER_TRANSFORM_CHUNK_BYTES", 2 * 3 * np.dtype(dtype).itemsize)
     bits = np.arange(3072 * np.dtype(dtype).itemsize, dtype=np.uint8)
     points = bits.view(dtype).reshape(-1, 3)
     encoded = _component_shuffle_bytes(points)
+    expected_layout = _shuffle_bytes(np.ascontiguousarray(points.T))
     recovered = _uncomponent_shuffle_bytes(encoded, points.dtype, points.shape)
+    assert encoded.tobytes() == expected_layout.tobytes()
     assert recovered.tobytes() == points.tobytes()
 
 
 @pytest.mark.parametrize("dtype", [np.int32, np.int64, np.uint32, np.uint64])
-def test_triangle_delta_shuffle_roundtrip_is_bit_exact(dtype: type[np.integer]) -> None:
+def test_triangle_delta_shuffle_roundtrip_is_bit_exact(
+    dtype: type[np.integer],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Same-dtype modular deltas preserve signed and unsigned connectivity."""
+    monkeypatch.setattr(_pz_mod, "_FILTER_TRANSFORM_CHUNK_BYTES", 2 * 3 * np.dtype(dtype).itemsize)
     info = np.iinfo(dtype)
     triangles = np.array(
         [[0, 1, 2], [9, 4, 7], [info.max, 0, info.min], [3, 2, 1]],
@@ -103,6 +114,18 @@ def test_mesh_filters_false_preserves_version_2(polydata: pv.PolyData, tmp_path:
     pz.write(polydata, path, mesh_filters=False)
     assert pz.Reader(path)._metadata.file_version == FILE_VERSION_FIXED_WIDTH_CELLS  # noqa: SLF001
     assert pz.read(path) == polydata
+
+
+def test_auto_skips_tiny_mesh_frames_but_true_forces_them(tmp_path: Path) -> None:
+    """Automatic filtering avoids format promotion when the payload is negligible."""
+    pointset = pv.PointSet(np.arange(30, dtype=np.float32).reshape(-1, 3))
+    automatic = tmp_path / "automatic.pv"
+    forced = tmp_path / "forced.pv"
+    pz.write(pointset, automatic)
+    pz.write(pointset, forced, mesh_filters=True)
+    assert pz.Reader(automatic)._metadata.file_version == FILE_VERSION_UNFILTERED  # noqa: SLF001
+    assert pz.Reader(forced)._metadata.file_version == FILE_VERSION_MESH_FILTERS  # noqa: SLF001
+    assert pz.read(forced).points.tobytes() == pointset.points.tobytes()
 
 
 def test_auto_skips_mesh_filters_for_incompressible_samples(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Store explicit point coordinates in component-major byte planes before zstd compression.
- Store homogeneous triangle connectivity as same-dtype triangle-to-triangle deltas followed by byte shuffle.
- Select each lossless transform only when a fast centered trial beats the requested generic representation. `mesh_filters=False` retains format version 2; `True` skips the probe and forces eligible filters.
- Process encode/decode in cache-sized chunks to reduce memory traffic and avoid a full-size triangle-delta temporary.
- Stamp files using either mesh transform as format version 3 and reject unsupported future versions.

## Size impact

On a 16,260,963-triangle scan at zstd level 3, merged-main fixed-width storage produced 147,958,907 bytes. The two mesh filters produced 79,670,264 bytes, a 46.1 percent reduction. Both outputs round-tripped point and connectivity bytes exactly.

## Performance

`benchmarks/benchmark-mesh-filters.py` measures direct transform/probe cost and end-to-end storage with single-threaded zstd level 3. It covers three 977,202-triangle synthetic meshes plus four real triangle meshes from `pyvista.examples`. Values are medians after an untimed warmup; negative time deltas are faster.

| Dataset | Triangles | Size reduction | Auto write delta | Filtered read delta |
| --- | ---: | ---: | ---: | ---: |
| Synthetic ordered | 977,202 | 89.8% | -80.4% | -54.0% |
| Synthetic scrambled | 977,202 | 33.5% | -27.4% | +8.6% |
| Synthetic random | 977,202 | 10.1% | -20.9% | +80.6% |
| PyVista bunny | 69,451 | 10.8% | +25.1% | +18.7% |
| PyVista horse | 67,868 | 11.5% | +45.7% | +13.3% |
| PyVista woman | 300,000 | 12.4% | -14.8% | +28.5% |
| PyVista Louis Louvre | 421,965 | 10.5% | -19.0% | +19.6% |

The fixed probe dominates the two smallest writes. Forced mode removes it and writes bunny and horse 24.0 and 22.8 percent faster than format version 2, respectively.

Against the first PR commit, automatic writes improve by 13 to 43 percent and reads improve by 7 to 57 percent across the shared datasets. On the large scan, write time drops from 0.401 to 0.340 seconds and read time drops from 0.608 to 0.316 seconds. Relative to format version 2, the final scan writes 52.7 percent faster and reads 21.4 percent slower.

### Direct transform cost

These medians were measured on an Intel Xeon E-2288G with Python 3.13.11, PyVista 0.48.4, VTK 9.6.2, and NumPy 2.5.1. The first four columns isolate the lossless transform CPU cost. Automatic mode additionally pays both probe costs, shown combined in the last column.

| Dataset | Point encode | Point decode | Triangle encode | Triangle decode | Auto probes |
| --- | ---: | ---: | ---: | ---: | ---: |
| Synthetic ordered | 4.94 ms | 3.26 ms | 8.18 ms | 9.66 ms | 8.61 ms |
| Synthetic scrambled | 4.78 ms | 3.28 ms | 6.92 ms | 10.44 ms | 8.56 ms |
| Synthetic random | 3.22 ms | 2.77 ms | 6.52 ms | 9.98 ms | 4.86 ms |
| PyVista bunny | 0.30 ms | 0.26 ms | 0.57 ms | 0.74 ms | 6.70 ms |
| PyVista horse | 0.28 ms | 0.27 ms | 0.54 ms | 0.74 ms | 10.16 ms |
| PyVista woman | 1.03 ms | 1.00 ms | 2.32 ms | 2.95 ms | 11.28 ms |
| PyVista Louis Louvre | 1.47 ms | 1.41 ms | 3.11 ms | 4.18 ms | 7.67 ms |

Forced writes spend 0.82 to 13.12 ms in the two encoders. Filtered reads spend 1.00 to 12.93 ms in the two decoders. Automatic selection adds 4.86 to 11.28 ms before encoding when the filters are accepted. That fixed selection cost explains the small-mesh regression; the transforms themselves are sub-millisecond for bunny and horse.

### Relative CPU cost

These percentages normalize the direct costs against the corresponding format-version-2 end-to-end operation. They come from an 11-repeat run pinned to one CPU core; the three synthetic datasets use five timed repeats under the benchmark's large-mesh policy.

| Dataset | Encoders / v2 write | Auto probes / v2 write | Decoders / v2 read |
| --- | ---: | ---: | ---: |
| Synthetic ordered | 5.6% | 4.7% | 22.3% |
| Synthetic scrambled | 5.4% | 4.3% | 36.3% |
| Synthetic random | 7.1% | 3.5% | 57.4% |
| PyVista bunny | 6.6% | 51.6% | 29.8% |
| PyVista horse | 6.5% | 74.7% | 27.8% |
| PyVista woman | 7.7% | 24.6% | 29.1% |
| PyVista Louis Louvre | 5.9% | 9.9% | 32.5% |

The encoders add 5.4 to 7.7 percent of the previous total write time. The decoders add 22.3 to 57.4 percent of the previous total read time; the real example meshes cluster between 27.8 and 32.5 percent. Automatic selection adds 3.5 to 74.7 percent of the previous write time. That range is size-dependent: the fixed probe is 3.5 to 4.7 percent on the million-triangle synthetic meshes but 51.6 to 74.7 percent on bunny and horse.

These are gross CPU costs before accounting for the reduced zstd workload. The end-to-end results can still be faster because the transformed representation compresses more quickly and produces fewer bytes.

## Compatibility

Versions 0 through 2 continue to read. Mixed-width or non-triangle topology keeps its existing representation, all-triangle PolyData and UnstructuredGrid are covered, and older readers reject version 3 instead of returning corrupt arrays. Automatic mode skips payloads below 4 KiB to avoid promoting negligible files; `mesh_filters=True` remains an explicit override.

## Validation

- 100 tests pass on Python 3.13 / VTK 9.6.2 with 96.2 percent coverage.
- 99 tests pass with 1 expected skip on Python 3.11 / VTK 9.2.6 with 95.8 percent coverage.
- All pre-commit hooks pass.

## AI Usage

Used ChatGPT's [GPT-5.6](https://openai.com/index/gpt-5-6/). Reviewed with my eyeballs before committing. My idea, it's implementation. I asked it to limit this work to lossless component-planar and triangle-delta byte-shuffle transforms, benchmark synthetic and real PyVista meshes, preserve a version-2 compatibility path, and profile and improve the implementation before merge.
