### PR TITLE
Import VTK through PyVista instead of vtkmodules

### DIFF
--- a/src/pyvista_zstd/pyvista_zstd.py
+++ b/src/pyvista_zstd/pyvista_zstd.py
@@ -32,13 +32,22 @@ import pyvista as pv
 # ``TypeError: SetPolys argument 1:`` and every ``.pv`` file becomes unreadable.
 #
 # ``pyvista._vtk`` resolves to whichever binding is in use, so this is a no-op
-# on a stock install and correct on the others.
-from pyvista._vtk import numpy_to_vtk
-from pyvista._vtk import vtk_to_numpy
-from pyvista._vtk import vtkCellArray
-from pyvista._vtk import vtkPointSet
-from pyvista._vtk import vtkTypeInt32Array
-from pyvista._vtk import vtkTypeInt64Array
+# on a stock install and correct on the others.  That module was added in
+# pyvista 0.48; before then the same names lived in ``pyvista.core._vtk_core``.
+try:  # pyvista >= 0.48
+    from pyvista._vtk import numpy_to_vtk
+    from pyvista._vtk import vtk_to_numpy
+    from pyvista._vtk import vtkCellArray
+    from pyvista._vtk import vtkPointSet
+    from pyvista._vtk import vtkTypeInt32Array
+    from pyvista._vtk import vtkTypeInt64Array
+except ModuleNotFoundError:  # pyvista < 0.48
+    from pyvista.core._vtk_core import numpy_to_vtk
+    from pyvista.core._vtk_core import vtk_to_numpy
+    from pyvista.core._vtk_core import vtkCellArray
+    from pyvista.core._vtk_core import vtkPointSet
+    from pyvista.core._vtk_core import vtkTypeInt32Array
+    from pyvista.core._vtk_core import vtkTypeInt64Array
 from pyvista.core.composite import MultiBlock
 from pyvista.core.grid import ImageData
 from pyvista.core.grid import RectilinearGrid

--- a/src/pyvista_zstd/pyvista_zstd.py
+++ b/src/pyvista_zstd/pyvista_zstd.py
@@ -22,6 +22,23 @@ import warnings
 
 import numpy as np
 import pyvista as pv
+
+# Import VTK through PyVista rather than from ``vtkmodules`` directly, so the
+# classes constructed here always come from the same VTK binding PyVista itself
+# is built on. PyVista can be built against a binding other than the stock
+# ``vtkmodules`` wheel -- ``cvista``, for instance -- and in that case a
+# ``vtkmodules`` cell array is a different C++ type from the one a PyVista
+# ``PolyData`` expects. ``SetPolys`` then rejects it with a bare
+# ``TypeError: SetPolys argument 1:`` and every ``.pv`` file becomes unreadable.
+#
+# ``pyvista._vtk`` resolves to whichever binding is in use, so this is a no-op
+# on a stock install and correct on the others.
+from pyvista._vtk import numpy_to_vtk
+from pyvista._vtk import vtk_to_numpy
+from pyvista._vtk import vtkCellArray
+from pyvista._vtk import vtkPointSet
+from pyvista._vtk import vtkTypeInt32Array
+from pyvista._vtk import vtkTypeInt64Array
 from pyvista.core.composite import MultiBlock
 from pyvista.core.grid import ImageData
 from pyvista.core.grid import RectilinearGrid
@@ -31,12 +48,6 @@ from pyvista.core.pointset import PolyData
 from pyvista.core.pointset import StructuredGrid
 from pyvista.core.pointset import UnstructuredGrid
 from tqdm import tqdm
-from vtkmodules.util.numpy_support import numpy_to_vtk
-from vtkmodules.util.numpy_support import vtk_to_numpy
-from vtkmodules.vtkCommonCore import vtkTypeInt32Array
-from vtkmodules.vtkCommonCore import vtkTypeInt64Array
-from vtkmodules.vtkCommonDataModel import vtkCellArray
-from vtkmodules.vtkCommonDataModel import vtkPointSet
 import zstandard as zstd
 from zstandard import BufferSegment
 from zstandard import BufferWithSegments

--- a/tests/test_fixed_width_cells.py
+++ b/tests/test_fixed_width_cells.py
@@ -49,14 +49,22 @@ def test_homogeneous_polydata_omits_offsets(polydata: pv.PolyData, tmp_path: Pat
 def test_homogeneous_ugrid_omits_offsets(ugrid: pv.UnstructuredGrid, tmp_path: Path) -> None:
     """The fixed-width encoding applies to homogeneous non-triangle cells too."""
     path = tmp_path / "hexahedra.pv"
+    source_dtype = ugrid.cell_connectivity.dtype
+    source_connectivity = ugrid.cell_connectivity.copy()
     pz.write(ugrid, path, force_int32=False)
 
     reader = pz.Reader(path)
     frame_names = reader._metadata.frame_names  # noqa: SLF001
     assert _frame_name(reader, CELLS, OFFSET_SUFFIX) not in frame_names
     assert reader._ds_metadata.fixed_cell_sizes[CELLS] == HEXAHEDRON_SIZE  # noqa: SLF001
-    assert reader.read() == ugrid
-    assert reader.read().cell_connectivity.dtype == np.int64
+    result = reader.read()
+    assert result == ugrid
+    # The connectivity width is a property of the VTK build, not something this
+    # library chooses, so compare against what the source was given rather than
+    # asserting int64 outright. Values are compared too, so a correctly typed
+    # but corrupted array still fails.
+    assert result.cell_connectivity.dtype == source_dtype
+    assert np.array_equal(result.cell_connectivity, source_connectivity)
 
 
 def test_equal_width_different_cell_types_use_fixed_width(tmp_path: Path) -> None:

--- a/tests/test_pyvista_zstd.py
+++ b/tests/test_pyvista_zstd.py
@@ -9,6 +9,7 @@ import warnings
 import numpy as np
 import pytest
 import pyvista as pv
+from pyvista import _vtk
 from pyvista.core.composite import MultiBlock
 from pyvista.core.grid import ImageData
 from pyvista.core.grid import RectilinearGrid
@@ -19,6 +20,7 @@ from pyvista.core.pointset import StructuredGrid
 from pyvista.core.pointset import UnstructuredGrid
 
 import pyvista_zstd
+from pyvista_zstd import pyvista_zstd as module
 
 if TYPE_CHECKING:
     from pyvista.core.dataset import DataSet
@@ -688,3 +690,34 @@ def test_esgrid(esgrid: ExplicitStructuredGrid, tmp_path: Path) -> None:
     assert "Point arrays" not in repr_no_data_str
     assert "Cell arrays" not in repr_no_data_str
     assert "Field arrays" not in repr_no_data_str
+
+
+def test_vtk_classes_come_from_pyvistas_binding() -> None:
+    """
+    The VTK classes used internally must match PyVista's own binding.
+
+    PyVista is not always built against the stock ``vtkmodules`` wheel. When it
+    is built on another binding, a ``vtkmodules`` cell array is a different C++
+    type from the one a PyVista ``PolyData`` accepts, and handing one to the
+    other fails with a bare ``TypeError: SetPolys argument 1:``. That breaks
+    reading of every ``.pv`` file, so assert the classes are the same objects
+    PyVista would use.
+    """
+    assert module.vtkCellArray is _vtk.vtkCellArray
+    assert module.vtkPointSet is _vtk.vtkPointSet
+    assert module.vtkTypeInt32Array is _vtk.vtkTypeInt32Array
+    assert module.vtkTypeInt64Array is _vtk.vtkTypeInt64Array
+
+
+def test_cell_array_binds_to_pyvista_polydata() -> None:
+    """
+    Reproduce the failure directly: the reader's cell array must bind.
+
+    ``_segments_to_polydata`` builds a PyVista ``PolyData`` and calls
+    ``SetPolys`` on it with a cell array constructed from the imports under
+    test. This exercises that exact pairing, so a binding mismatch fails here
+    with a clear message rather than as an unreadable file.
+    """
+    polydata = PolyData()
+    polydata.points = np.zeros((3, 3))
+    polydata.SetPolys(module.vtkCellArray())

--- a/tests/test_pyvista_zstd.py
+++ b/tests/test_pyvista_zstd.py
@@ -454,19 +454,35 @@ def test_read_sphere_v2_pv_fixture() -> None:
     assert np.array_equal(out.cell_data["ids"], expected.cell_data["ids"])
 
 
-def test_use_int64(ugrid: UnstructuredGrid, tmp_path: Path) -> None:
-    """Test Reader class with array sub-selection."""
+def test_roundtrip_preserves_connectivity_dtype(ugrid: UnstructuredGrid, tmp_path: Path) -> None:
+    """
+    A round trip returns the connectivity dtype it was given.
+
+    The width of VTK's cell-array storage is a property of the build, not
+    something this library chooses: a binding may use 32-bit storage whenever
+    the values fit, so ``GetCells()`` can hand over int32 before this library is
+    involved at all. Asserting int64 outright therefore tests the binding's
+    storage policy rather than anything here.
+
+    What this library does control is narrower and is what gets asserted:
+    ``force_int32=False`` must not change the dtype, and ``force_int32=True``
+    must narrow it to int32. Values are compared as well as dtypes, so an array
+    that comes back correctly typed but corrupted still fails.
+    """
     populate_data(ugrid)
 
     tmp_filename = tmp_path / "ugrid.pv"
+    source_dtype = ugrid.cell_connectivity.dtype
 
     pyvista_zstd.write(ugrid, tmp_filename, force_int32=False)
     ugrid_out = pyvista_zstd.read(tmp_filename)
-    assert ugrid_out.cell_connectivity.dtype == np.int64
+    assert ugrid_out.cell_connectivity.dtype == source_dtype
+    assert np.array_equal(ugrid_out.cell_connectivity, ugrid.cell_connectivity)
 
     pyvista_zstd.write(ugrid, tmp_filename, force_int32=True)
     ugrid_out = pyvista_zstd.read(tmp_filename)
     assert ugrid_out.cell_connectivity.dtype == np.int32
+    assert np.array_equal(ugrid_out.cell_connectivity, ugrid.cell_connectivity)
 
 
 def test_future_version_is_rejected(ugrid: UnstructuredGrid, tmp_path: Path) -> None:

--- a/tests/test_pyvista_zstd.py
+++ b/tests/test_pyvista_zstd.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 from typing import TYPE_CHECKING
 import warnings
@@ -9,7 +10,6 @@ import warnings
 import numpy as np
 import pytest
 import pyvista as pv
-from pyvista import _vtk
 from pyvista.core.composite import MultiBlock
 from pyvista.core.grid import ImageData
 from pyvista.core.grid import RectilinearGrid
@@ -20,7 +20,7 @@ from pyvista.core.pointset import StructuredGrid
 from pyvista.core.pointset import UnstructuredGrid
 
 import pyvista_zstd
-from pyvista_zstd import pyvista_zstd as module
+from pyvista_zstd import pyvista_zstd as impl
 
 if TYPE_CHECKING:
     from pyvista.core.dataset import DataSet
@@ -708,32 +708,35 @@ def test_esgrid(esgrid: ExplicitStructuredGrid, tmp_path: Path) -> None:
     assert "Field arrays" not in repr_no_data_str
 
 
-def test_vtk_classes_come_from_pyvistas_binding() -> None:
+def test_vtk_imports_route_through_pyvista() -> None:
     """
-    The VTK classes used internally must match PyVista's own binding.
+    VTK must be imported through PyVista, never from ``vtkmodules`` or ``vtk``.
 
     PyVista is not always built against the stock ``vtkmodules`` wheel. When it
     is built on another binding, a ``vtkmodules`` cell array is a different C++
     type from the one a PyVista ``PolyData`` accepts, and handing one to the
     other fails with a bare ``TypeError: SetPolys argument 1:``. That breaks
-    reading of every ``.pv`` file, so assert the classes are the same objects
-    PyVista would use.
+    reading of every ``.pv`` file. An identity check cannot catch this on a
+    single-binding install, so assert on the import statements themselves.
     """
-    assert module.vtkCellArray is _vtk.vtkCellArray
-    assert module.vtkPointSet is _vtk.vtkPointSet
-    assert module.vtkTypeInt32Array is _vtk.vtkTypeInt32Array
-    assert module.vtkTypeInt64Array is _vtk.vtkTypeInt64Array
+    tree = ast.parse(Path(impl.__file__).read_text(encoding="utf-8"))
+    roots = {(node.module or "").split(".")[0] for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)} | {
+        alias.name.split(".")[0] for node in ast.walk(tree) if isinstance(node, ast.Import) for alias in node.names
+    }
+    assert "vtkmodules" not in roots
+    assert "vtk" not in roots
 
 
 def test_cell_array_binds_to_pyvista_polydata() -> None:
     """
-    Reproduce the failure directly: the reader's cell array must bind.
+    Smoke-test the pairing the reader relies on: the cell array must bind.
 
     ``_segments_to_polydata`` builds a PyVista ``PolyData`` and calls
     ``SetPolys`` on it with a cell array constructed from the imports under
-    test. This exercises that exact pairing, so a binding mismatch fails here
-    with a clear message rather than as an unreadable file.
+    test. This exercises that exact pairing. On a stock single-binding install
+    it passes either way, so it only has teeth where PyVista is built against a
+    binding other than the ``vtkmodules`` wheel.
     """
     polydata = PolyData()
     polydata.points = np.zeros((3, 3))
-    polydata.SetPolys(module.vtkCellArray())
+    polydata.SetPolys(impl.vtkCellArray())


### PR DESCRIPTION
## Summary

- Import the VTK symbols through PyVista instead of `vtkmodules`, so the objects this package builds come from whichever binding PyVista is using.
- Assert that a round trip preserves the connectivity dtype, instead of asserting it is always int64.

## The binding bug

We populate PyVista objects with classes imported straight from `vtkmodules`, which only holds while PyVista is built on the stock wheel. On another binding a `vtkmodules` `vtkCellArray` is a different C++ type from the one a `PolyData` accepts, so `_segments_to_polydata` dies on `SetPolys` with a bare `TypeError: SetPolys argument 1:` and `.pv` files become unreadable. Nothing in that error points at two bindings being loaded, and the class hierarchy does not either: on a mixed install `PolyData` inherits `vtkPolyData` from one binding and `vtkPointSet` from the other, and `cvista`'s classes report `__module__ == "vtkmodules.vtkCommonDataModel"` while being distinct types. Finding it meant bisecting `SetPolys` against each installed binding.

On every released PyVista these resolve to the same objects, so this is a no-op today and correct on the bindings where it isn't. It also stops us importing from a dependency we don't declare: the `vtk` pin was dropped in #25.

The import route moved in PyVista 0.48 (`pyvista.core._vtk_core` to `pyvista._vtk`), so it goes through a try/except to keep working at our declared `pyvista>=0.45.0` floor. That fallback is deliberate rather than defensive: the module has moved once already.

## The dtype test

`test_use_int64` asserted int64 connectivity after writing with `force_int32=False`. Storage width is a property of the VTK build rather than something this library picks, and the writer only ever narrows, so on a binding using 32-bit storage the test failed while the library was behaving correctly. It now asserts what we control: `force_int32=False` preserves the dtype it was given, `force_int32=True` narrows to int32. Values are compared alongside dtypes, so a correctly typed but corrupted array no longer passes. #33 added a third copy of the same assertion, fixed here too.

## AI Usage

Drafted with Claude Opus 5, reviewed by me before pushing. My diagnosis, it's implementation. A second Claude reviewed the diff cold and caught that the new import breaks PyVista 0.45 to 0.47, that both binding tests were tautologies that pass with the fix reverted, and two wrong numbers in my original description.
