### PR TITLE
Assert the round trip preserves the connectivity dtype

### DIFF
--- a/tests/test_pyvista_zstd.py
+++ b/tests/test_pyvista_zstd.py
@@ -452,19 +452,35 @@ def test_read_sphere_v2_pv_fixture() -> None:
     assert np.array_equal(out.cell_data["ids"], expected.cell_data["ids"])
 
 
-def test_use_int64(ugrid: UnstructuredGrid, tmp_path: Path) -> None:
-    """Test Reader class with array sub-selection."""
+def test_roundtrip_preserves_connectivity_dtype(ugrid: UnstructuredGrid, tmp_path: Path) -> None:
+    """
+    A round trip returns the connectivity dtype it was given.
+
+    The width of VTK's cell-array storage is a property of the build, not
+    something this library chooses: a binding may use 32-bit storage whenever
+    the values fit, so ``GetCells()`` can hand over int32 before this library is
+    involved at all. Asserting int64 outright therefore tests the binding's
+    storage policy rather than anything here.
+
+    What this library does control is narrower and is what gets asserted:
+    ``force_int32=False`` must not change the dtype, and ``force_int32=True``
+    must narrow it to int32. Values are compared as well as dtypes, so an array
+    that comes back correctly typed but corrupted still fails.
+    """
     populate_data(ugrid)
 
     tmp_filename = tmp_path / "ugrid.pv"
+    source_dtype = ugrid.cell_connectivity.dtype
 
     pyvista_zstd.write(ugrid, tmp_filename, force_int32=False)
     ugrid_out = pyvista_zstd.read(tmp_filename)
-    assert ugrid_out.cell_connectivity.dtype == np.int64
+    assert ugrid_out.cell_connectivity.dtype == source_dtype
+    assert np.array_equal(ugrid_out.cell_connectivity, ugrid.cell_connectivity)
 
     pyvista_zstd.write(ugrid, tmp_filename, force_int32=True)
     ugrid_out = pyvista_zstd.read(tmp_filename)
     assert ugrid_out.cell_connectivity.dtype == np.int32
+    assert np.array_equal(ugrid_out.cell_connectivity, ugrid.cell_connectivity)
 
 
 def test_future_version_is_rejected(ugrid: UnstructuredGrid, tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

`test_use_int64` asserted that writing with `force_int32=False` and reading back yields int64 connectivity:

```python
pyvista_zstd.write(ugrid, tmp_filename, force_int32=False)
ugrid_out = pyvista_zstd.read(tmp_filename)
assert ugrid_out.cell_connectivity.dtype == np.int64
```

That holds only if VTK handed the writer a 64-bit cell array to begin with. Storage width is a property of the VTK build, not a choice this library makes — a binding may use 32-bit storage whenever the values fit, so `GetCells()` can return int32 before this library is involved at all.

The writer never widens; it only narrows:

```python
if force_int32 and connectivity.size <= np.iinfo(np.int32).max:
    connectivity = connectivity.astype(np.int32, copy=False)
```

So with `force_int32=False` the library correctly leaves the dtype alone, and the test fails anyway. It was asserting the binding's storage policy rather than any behaviour of this package.

## Change

Assert what the library actually controls:

- `force_int32=False` returns the dtype it was given
- `force_int32=True` narrows to int32

Both hold on any binding — on a build defaulting to 64-bit storage this still asserts int64 survives the round trip, so no coverage is lost.

Values are now compared alongside dtypes, so an array that comes back correctly typed but corrupted no longer passes. Renamed to match what it tests, and the docstring replaced: it read *"Test Reader class with array sub-selection"*, which this test has never done.

## Rejected alternative

Calling `ConvertTo64BitStorage()` on the fixture to force the 64-bit case. It works, but it makes the test manufacture the very condition it then asserts, and it tests VTK's conversion rather than this library's round trip.

## Verification

Test-only change; no source is touched.

Locally this build uses 32-bit storage (`vtkCellArray().IsStorage64Bit()` is `False`), which is what exposed the bad assumption. Full suite passes — **76 passed, 0 failed** — with #35 applied on top, since without that fix `.pv` files cannot be read on this binding at all. On stock VTK the connectivity is int64 and the same assertions hold.

Independent of #35 and mergeable in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MKkKs2b1LJAkiW1oBP1gSv
