### PR TITLE
Allow a zero-byte array read with a null destination

### DIFF
--- a/cpp/src/reader.cpp
+++ b/cpp/src/reader.cpp
@@ -545,11 +545,12 @@ int64_t pvzstd_find_array(const pvzstd_reader *reader, const char *name) try {
 
 pvzstd_status pvzstd_read_array_at(const pvzstd_reader *reader, uint64_t index, void *dst,
                                    uint64_t dst_size) try {
-  if (reader == nullptr || dst == nullptr) return PVZSTD_E_INVALID;
+  if (reader == nullptr) return PVZSTD_E_INVALID;
   if (index >= reader->arrays.size()) return PVZSTD_E_RANGE;
   const ArrayEntry &e = reader->arrays[static_cast<size_t>(index)];
   if (dst_size < e.nbytes) return PVZSTD_E_RANGE;
   if (e.nbytes == 0) return PVZSTD_OK;
+  if (dst == nullptr) return PVZSTD_E_INVALID;
 
   const uint8_t *src = reader->map.data() + e.payload_start;
   const uint64_t src_size = e.payload_end - e.payload_start;

--- a/tests/conformance/test_c_abi_runtime.py
+++ b/tests/conformance/test_c_abi_runtime.py
@@ -105,6 +105,48 @@ def test_a_library_without_the_symbols_is_a_load_failure() -> None:
     assert verdict == "CoreUnavailableError", done.stdout
 
 
+def test_read_array_at_accepts_a_null_destination_for_a_zero_byte_array(tmp_path: Path) -> None:
+    """A zero-byte read must succeed even with a null destination.
+
+    ``pv.Sphere()`` has no lines, verts, or strips, so its
+    ``lines_connectivity``, ``verts_connectivity`` and ``strips_connectivity``
+    frames are zero bytes. numpy always hands back a non-null pointer for a
+    zero-size array, so going through :meth:`CoreReader.read_at` cannot
+    exercise a null destination the way a C or C++ caller sizing its buffer
+    from ``nbytes`` would; this reads every array through the raw ctypes
+    entry point instead, passing ``None`` whenever ``nbytes`` is zero.
+    """
+    ds = pv.Sphere()
+    path = tmp_path / "empty_topology.pv"
+    write(ds, path)
+
+    with _capi.CoreReader(str(path)) as reader:
+        count = len(reader)
+        assert count > 0
+
+        saw_empty = False
+        for index in range(count):
+            info = reader._info(index)  # noqa: SLF001
+            nbytes = int(info.nbytes)
+            if nbytes == 0:
+                saw_empty = True
+                dst = None
+            else:
+                buf = np.empty(nbytes, dtype=np.uint8)
+                dst = buf.ctypes.data_as(ctypes.c_void_p)
+
+            status = reader._lib.pvzstd_read_array_at(  # noqa: SLF001
+                reader._live,  # noqa: SLF001
+                ctypes.c_uint64(index),
+                dst,
+                ctypes.c_uint64(nbytes),
+            )
+            name = info.name.decode("utf-8")
+            assert status == _capi._STATUS_OK, f"array {index} ({name}, {nbytes} bytes) returned {status}"  # noqa: SLF001
+
+        assert saw_empty, "need at least one zero-byte array for this test to mean anything"
+
+
 def test_read_arrays_decodes_the_same_bytes_at_every_thread_setting(container: str) -> None:
     """The worker count is a schedule, not an answer: every setting decodes the same bytes."""
     settings = [_capi.THREADS_AUTO, 0, 1, 2, -1]


### PR DESCRIPTION
`pvzstd_read_array_at` checked `dst == nullptr` before the zero-size early-out, so reading a 0-byte array into a 0-size buffer came back `PVZSTD_E_INVALID` instead of `PVZSTD_OK`.

Resolves #43.

Empty payloads are ordinary. A plain `pv.Sphere()` writes empty `lines_connectivity`, `verts_connectivity` and `strips_connectivity` frames, so three of its twelve arrays hit this. The container is fine and the read is meaningful; only the status was wrong. The Python binding never saw it because `read_at` short-circuits on `nbytes == 0` and never reaches the C entry point, and because numpy hands back a non-null pointer for a zero-size array either way. A C or C++ caller sizing its destination from `info.nbytes` gets the refusal on its first file.

The `reader == nullptr` check stays where it was. Only the destination check moves below `if (e.nbytes == 0) return PVZSTD_OK;`, so a zero-length read succeeds whatever the destination pointer is, and a null destination for a non-empty array still returns `PVZSTD_E_INVALID`.

`pvzstd_read_arrays` needed no change. It null-checks the batch pointer arrays themselves and delegates each slot to `pvzstd_read_array_at`, so it inherits the fix.

The test calls the C entry point directly through ctypes, with `dst=None`, for every array of a sphere container. It fails on `main` with `array 3 (lines_connectivity, 0 bytes) returned 7` and passes here.
