### PR TITLE
Export the pvzstd CMake target and add a pvzstd::pvzstd alias

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,9 +1,11 @@
 cmake_minimum_required(VERSION 3.16)
-# The Python distribution's own version comes from git tags via
-# setuptools_scm and has no fixed value at configure time. This VERSION is
-# only the CMake package's own compatibility version, for write_basic_package_version_file
-# below; it does not need to (and does not) track the Python version.
-project(pvzstd VERSION 0.1.0 LANGUAGES CXX)
+# Tracks the released version line, so `find_package(pvzstd 0.3)` means what a
+# reader expects. It cannot be derived: the Python distribution's version comes
+# from git tags through setuptools_scm and has no value at configure time. Bump
+# it when the release line moves. The real compatibility contract for a C or C++
+# consumer is PVZSTD_ABI_VERSION in the public header, which is checked for
+# equality rather than as a floor.
+project(pvzstd VERSION 0.3.1 LANGUAGES CXX)
 
 option(PVZSTD_BUILD_TOOLS "Build the pvzstd_dump conformance tool" ON)
 option(PVZSTD_BUILD_SHARED "Build a shared library (needed for the ctypes binding)" ON)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.16)
-project(pvzstd LANGUAGES CXX)
+# The Python distribution's own version comes from git tags via
+# setuptools_scm and has no fixed value at configure time. This VERSION is
+# only the CMake package's own compatibility version, for write_basic_package_version_file
+# below; it does not need to (and does not) track the Python version.
+project(pvzstd VERSION 0.1.0 LANGUAGES CXX)
 
 option(PVZSTD_BUILD_TOOLS "Build the pvzstd_dump conformance tool" ON)
 option(PVZSTD_BUILD_SHARED "Build a shared library (needed for the ctypes binding)" ON)
@@ -111,6 +115,10 @@ else()
   add_library(pvzstd STATIC src/reader.cpp src/writer.cpp src/append.cpp src/stream.cpp)
 endif()
 
+# Namespaced alias so a submodule / FetchContent consumer links the same
+# target name (pvzstd::pvzstd) that find_package(pvzstd) yields below.
+add_library(pvzstd::pvzstd ALIAS pvzstd)
+
 target_include_directories(pvzstd PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
@@ -146,8 +154,57 @@ if(PVZSTD_BUILD_TOOLS)
 endif()
 
 include(GNUInstallDirs)
+
+# --- Install / export ---------------------------------------------------
+#
+# zstd is linked PRIVATE (see target_link_libraries(pvzstd ...) above), and
+# the public headers are a pure C ABI that never names a zstd type, so zstd
+# is purely an implementation detail here, not something a consumer needs
+# to find. That holds cleanly for the default shared build
+# (PVZSTD_BUILD_SHARED=ON): a PRIVATE link into a shared library folds
+# zstd's object code into libpvzstd itself, so the installed library is
+# self-contained regardless of whether zstd was vendored or found on the
+# system.
+#
+# It does NOT hold for a static build (PVZSTD_BUILD_SHARED=OFF): CMake does
+# not fold a PRIVATE static link dependency's object code into the
+# resulting archive, so libpvzstd.a still needs zstd's symbols resolved at
+# the downstream link step, and this export does not declare that
+# dependency for a consumer -- zstd (vendored or system) is treated purely
+# as this build's own implementation detail, not a re-exported one. With a
+# system zstd a consumer can supply that themselves. With
+# PVZSTD_ZSTD_PROVIDER=vendored, zstd is pulled in via FetchContent as an
+# internal build-tree dependency; its own CMakeLists happens to install its
+# own findable "zstd" package alongside ours when install() runs (a side
+# effect of FetchContent adding it as a subdirectory, not something this
+# project arranges or guarantees), so it is not strictly unfindable, but
+# relying on that is fragile and not something to design around. Prefer the
+# default shared build for anything that will be installed and linked
+# downstream.
+set(PVZSTD_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/pvzstd")
+
 install(TARGETS pvzstd
+        EXPORT pvzstdTargets
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+install(EXPORT pvzstdTargets
+        FILE pvzstdTargets.cmake
+        NAMESPACE pvzstd::
+        DESTINATION ${PVZSTD_INSTALL_CMAKEDIR})
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/pvzstdConfig.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/pvzstdConfig.cmake"
+  INSTALL_DESTINATION "${PVZSTD_INSTALL_CMAKEDIR}")
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/pvzstdConfigVersion.cmake"
+  COMPATIBILITY SameMajorVersion)
+
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/pvzstdConfig.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/pvzstdConfigVersion.cmake"
+  DESTINATION "${PVZSTD_INSTALL_CMAKEDIR}")

--- a/cpp/cmake/pvzstdConfig.cmake.in
+++ b/cpp/cmake/pvzstdConfig.cmake.in
@@ -1,0 +1,11 @@
+@PACKAGE_INIT@
+
+# pvzstd links zstd PRIVATE and its public headers are a pure C ABI that
+# never names a zstd type, so zstd is an implementation detail and this
+# package does not need to re-find it: the default shared build already
+# bakes zstd's object code into libpvzstd. See the "Install / export"
+# comment in cpp/CMakeLists.txt for the static-build caveat.
+
+include("${CMAKE_CURRENT_LIST_DIR}/pvzstdTargets.cmake")
+
+check_required_components(pvzstd)


### PR DESCRIPTION
`install(TARGETS pvzstd)` had no `EXPORT` and there was no namespaced alias, so a project embedding this library had to link the bare target name `pvzstd` and hope that was the intended spelling.

Resolves #41.

`add_library(pvzstd::pvzstd ALIAS pvzstd)` covers the source-level consumer, the case that matters most: `add_subdirectory` or `FetchContent` now links `pvzstd::pvzstd`, and a typo in the target name fails at configure time instead of resolving to something unexpected. The install side adds `EXPORT pvzstdTargets` with a matching `install(EXPORT ... NAMESPACE pvzstd::)` and a generated config, so `find_package(pvzstd CONFIG)` produces the same target.

The generated config deliberately does not re-find zstd. zstd is linked `PRIVATE` and never appears in the public header, which is a pure C ABI that names no zstd type, so in the default shared build its object code is already inside `libpvzstd` and `ldd` on the installed library shows no zstd dependency at all.

The static case is the honest gap. A `PVZSTD_BUILD_SHARED=OFF` build does not fold a private static dependency into the archive, so a downstream consumer of an installed static `libpvzstd.a` still needs zstd resolved on its own link line, and this export makes no attempt to arrange that. It is documented in a comment next to the export rather than papered over.

The CMake package version is set to the released version line so `find_package(pvzstd 0.3)` means what a reader expects. It cannot be derived, since the Python distribution's version comes from git tags through setuptools_scm and has no value at configure time, so it is a second number that has to be bumped by hand when the release line moves. The real compatibility contract for a C or C++ consumer is `PVZSTD_ABI_VERSION`, which is checked for equality rather than as a floor.

Verified both consumer styles against throwaway projects: `FetchContent` against a local checkout, and `find_package(pvzstd CONFIG REQUIRED)` against a `cmake --install` tree. Both configure, build, link and print the expected ABI and version. No system zstd exists on the machine this was developed on, so the `system` provider was not exercised.
