### PR TITLE
Add pvzstd_open_memory to read a container already in memory

### DIFF
--- a/cpp/include/pvzstd/pvzstd.h
+++ b/cpp/include/pvzstd/pvzstd.h
@@ -98,15 +98,20 @@ PVZSTD_API pvzstd_status pvzstd_open_versioned(const char *path, pvzstd_reader *
 
 /* Open a container the caller already holds: `data` must point at `size`
  * contiguous bytes of a whole container. NULL, or a size of zero, is
- * PVZSTD_E_INVALID.
+ * PVZSTD_E_INVALID -- a zero size is a bad argument, where a zero-length file
+ * is a property of the thing opened and so reaches pvzstd_open as PVZSTD_E_IO.
+ * The two doors differ there on purpose; a caller writing one error handler
+ * over both should expect it.
  *
  * The bytes are borrowed, never copied: the caller owns the buffer and must
  * keep it allocated and unmodified until pvzstd_close(), which is what makes
  * this cheaper than staging the container somewhere the file entry point can
- * reach. For a caller that already has the bytes -- an archive member, an HTTP
- * response body, or a build with no filesystem to open a path on -- this is
- * pvzstd_open over the same container, and refuses a crafted buffer wherever
- * pvzstd_open would refuse a crafted file. */
+ * reach. Modifying it meanwhile is not detected: the offsets and sizes were
+ * read at open time, so the arrays read afterwards hold undefined contents and
+ * no status reports it. For a caller that already has the bytes -- an archive
+ * member, an HTTP response body, or a build with no filesystem to open a path
+ * on -- this is pvzstd_open over the same container, and refuses a crafted
+ * buffer wherever pvzstd_open would refuse a crafted file. */
 PVZSTD_API pvzstd_status pvzstd_open_memory(const void *data, uint64_t size, pvzstd_reader **out);
 
 /* As pvzstd_open_memory, additionally reporting the container's own

--- a/cpp/include/pvzstd/pvzstd.h
+++ b/cpp/include/pvzstd/pvzstd.h
@@ -31,7 +31,7 @@ extern "C" {
 
 /* Bumped on any change below, additions included -- callers check equality, not
  * a floor, because they bind every symbol up front. */
-#define PVZSTD_ABI_VERSION 9u
+#define PVZSTD_ABI_VERSION 10u
 
 /* Dtype-field width and dataset-UID prefix width. They coincide in the format. */
 #define PVZSTD_DTYPE_LEN 16
@@ -96,7 +96,29 @@ PVZSTD_API pvzstd_status pvzstd_open(const char *path, pvzstd_reader **out);
 PVZSTD_API pvzstd_status pvzstd_open_versioned(const char *path, pvzstd_reader **out,
                                                uint32_t *file_version);
 
-/* Release a reader. Safe to call with NULL. */
+/* Open a container the caller already holds: `data` must point at `size`
+ * contiguous bytes of a whole container. NULL, or a size of zero, is
+ * PVZSTD_E_INVALID.
+ *
+ * The bytes are borrowed, never copied: the caller owns the buffer and must
+ * keep it allocated and unmodified until pvzstd_close(), which is what makes
+ * this cheaper than staging the container somewhere the file entry point can
+ * reach. For a caller that already has the bytes -- an archive member, an HTTP
+ * response body, or a build with no filesystem to open a path on -- this is
+ * pvzstd_open over the same container, and refuses a crafted buffer wherever
+ * pvzstd_open would refuse a crafted file. */
+PVZSTD_API pvzstd_status pvzstd_open_memory(const void *data, uint64_t size, pvzstd_reader **out);
+
+/* As pvzstd_open_memory, additionally reporting the container's own
+ * file_version, on the same terms as pvzstd_open_versioned -- including when
+ * the open is refused for being too new. A caller reading from memory needs
+ * that number for the same reason a caller reading from a path does. */
+PVZSTD_API pvzstd_status pvzstd_open_memory_versioned(const void *data, uint64_t size,
+                                                      pvzstd_reader **out, uint32_t *file_version);
+
+/* Release a reader. Safe to call with NULL. A reader opened from memory
+ * borrows its bytes, so this releases only what the reader itself acquired --
+ * the caller's buffer is left alone, and is theirs to free afterwards. */
 PVZSTD_API void pvzstd_close(pvzstd_reader *reader);
 
 /* Number of arrays, excluding the two JSON metadata frames. */

--- a/cpp/src/reader.cpp
+++ b/cpp/src/reader.cpp
@@ -106,14 +106,19 @@ bool DeclaredSizeAgrees(const std::vector<uint64_t> &shape, const char *dtype, u
 // the crossover is machine-dependent.
 constexpr uint64_t kParallelDecompressFloor = 4ull << 20;
 
-// A read-only view of the file. Mapping rather than copying, so that opening a
-// container faults in only the frames actually read.
-class FileMapping {
+// A read-only view of the container's bytes: either mapped from a file, or
+// borrowed from a caller that already holds them. Mapping rather than copying,
+// so that opening a file faults in only the frames actually read; borrowing
+// rather than copying, so a caller holding the container pays for it once.
+//
+// The two cases differ only in where the bytes came from and who releases them.
+// That is what lets one parse serve both.
+class ContainerBytes {
  public:
-  FileMapping() = default;
-  ~FileMapping() { Reset(); }
-  FileMapping(const FileMapping &) = delete;
-  FileMapping &operator=(const FileMapping &) = delete;
+  ContainerBytes() = default;
+  ~ContainerBytes() { Reset(); }
+  ContainerBytes(const ContainerBytes &) = delete;
+  ContainerBytes &operator=(const ContainerBytes &) = delete;
 
   pvzstd_status Open(const char *path) {
     Reset();
@@ -156,11 +161,30 @@ class FileMapping {
     return PVZSTD_OK;
   }
 
+  // Take a byte range the caller owns. Nothing is opened, mapped or copied, so
+  // there is no file I/O anywhere on this path -- which is the whole point on a
+  // build with no filesystem to stage the bytes into. The range must outlive
+  // the reader; Reset() releases nothing here, because nothing was acquired.
+  pvzstd_status Borrow(const void *data, uint64_t size) {
+    Reset();
+    if (data == nullptr || size == 0) return PVZSTD_E_INVALID;
+    data_ = static_cast<const uint8_t *>(data);
+    size_ = size;
+    owned_ = false;
+    return PVZSTD_OK;
+  }
+
   const uint8_t *data() const { return data_; }
   uint64_t size() const { return size_; }
 
  private:
   void Reset() {
+    if (!owned_) {
+      data_ = nullptr;
+      size_ = 0;
+      owned_ = true;
+      return;
+    }
 #if defined(_WIN32)
     if (data_ != nullptr) UnmapViewOfFile(data_);
     if (mapping_ != nullptr) CloseHandle(mapping_);
@@ -178,6 +202,9 @@ class FileMapping {
 
   const uint8_t *data_ = nullptr;
   uint64_t size_ = 0;
+  // Whether this view acquired what it points at. False for a borrowed range,
+  // so closing a reader cannot unmap or close a buffer the caller still owns.
+  bool owned_ = true;
 #if defined(_WIN32)
   HANDLE handle_ = INVALID_HANDLE_VALUE;
   HANDLE mapping_ = nullptr;
@@ -189,7 +216,8 @@ class FileMapping {
 }  // namespace
 
 struct pvzstd_reader {
-  FileMapping map;
+  // The container's bytes: mapped from a file, or borrowed from the caller.
+  ContainerBytes map;
   std::vector<ArrayEntry> arrays;
   std::string ds_metadata;
   std::string file_metadata;
@@ -288,27 +316,15 @@ pvzstd_status ParseHeader(const std::vector<uint8_t> &buf, ArrayEntry *entry) {
   return PVZSTD_OK;
 }
 
-}  // namespace
-
-extern "C" {
-
-pvzstd_status pvzstd_open_versioned(const char *path, pvzstd_reader **out,
-                                    uint32_t *file_version) try {
-  if (path == nullptr || out == nullptr) return PVZSTD_E_INVALID;
-  *out = nullptr;
-
-  // Owning: eleven paths below refuse the container, and the function-try
-  // handler catches throws from decompression sized by a field read out of
-  // the file. A raw pointer leaked the fd and the mapping on that last one.
-  std::unique_ptr<pvzstd_reader> reader(new (std::nothrow) pvzstd_reader());
-  if (reader == nullptr) return PVZSTD_E_NOMEM;
-
-  pvzstd_status st = reader->map.Open(path);
-  if (st != PVZSTD_OK) {
-    return st;
-  }
-
-  const FileMapping &raw = reader->map;
+// Parse a container out of the bytes the reader already points at, however it
+// came by them. Every entry point that produces a reader meets here, because a
+// second copy of this walk would be a second set of bounds checks to keep in
+// step with the first -- and it is these refusals, not the source of the bytes,
+// that stand between a crafted container and an out-of-bounds read.
+//
+// Throws are left to the entry point's function-try handler.
+pvzstd_status ParseContainer(pvzstd_reader *reader, uint32_t *file_version) {
+  const ContainerBytes &raw = reader->map;
   if (raw.size() < kTrailerCountBytes) {
     return PVZSTD_E_FORMAT;
   }
@@ -357,8 +373,8 @@ pvzstd_status pvzstd_open_versioned(const char *path, pvzstd_reader **out,
       return PVZSTD_E_FORMAT;
     }
 
-    st = DecompressFrame(raw.data() + hdr_start, hdr_end - hdr_start, sizes[static_cast<size_t>(i)],
-                         &frame);
+    pvzstd_status st = DecompressFrame(raw.data() + hdr_start, hdr_end - hdr_start,
+                                       sizes[static_cast<size_t>(i)], &frame);
     if (st != PVZSTD_OK) {
       return st;
     }
@@ -444,6 +460,34 @@ pvzstd_status pvzstd_open_versioned(const char *path, pvzstd_reader **out,
     }
   }
 
+  return PVZSTD_OK;
+}
+
+}  // namespace
+
+extern "C" {
+
+pvzstd_status pvzstd_open_versioned(const char *path, pvzstd_reader **out,
+                                    uint32_t *file_version) try {
+  if (path == nullptr || out == nullptr) return PVZSTD_E_INVALID;
+  *out = nullptr;
+
+  // Owning: the parse below refuses the container on eleven paths and can throw
+  // from a decompression sized by a field read out of the file, and every one of
+  // those has to give back the fd and the mapping. A raw pointer leaked both.
+  std::unique_ptr<pvzstd_reader> reader(new (std::nothrow) pvzstd_reader());
+  if (reader == nullptr) return PVZSTD_E_NOMEM;
+
+  pvzstd_status st = reader->map.Open(path);
+  if (st != PVZSTD_OK) {
+    return st;
+  }
+
+  st = ParseContainer(reader.get(), file_version);
+  if (st != PVZSTD_OK) {
+    return st;
+  }
+
   *out = reader.release();
   return PVZSTD_OK;
 } catch (...) {
@@ -452,6 +496,40 @@ pvzstd_status pvzstd_open_versioned(const char *path, pvzstd_reader **out,
 
 pvzstd_status pvzstd_open(const char *path, pvzstd_reader **out) try {
   return pvzstd_open_versioned(path, out, nullptr);
+} catch (...) {
+  return PVZSTD_E_NOMEM;
+}
+
+pvzstd_status pvzstd_open_memory_versioned(const void *data, uint64_t size, pvzstd_reader **out,
+                                           uint32_t *file_version) try {
+  if (data == nullptr || size == 0 || out == nullptr) return PVZSTD_E_INVALID;
+  *out = nullptr;
+
+  std::unique_ptr<pvzstd_reader> reader(new (std::nothrow) pvzstd_reader());
+  if (reader == nullptr) return PVZSTD_E_NOMEM;
+
+  // Where the bytes came from is the only difference from the file case: no
+  // path is opened and nothing is copied, and the parse below is the same call,
+  // so a crafted buffer meets the trailer bounds check, the divide-first
+  // frame-count guard and the declared-size check exactly as a crafted file does.
+  pvzstd_status st = reader->map.Borrow(data, size);
+  if (st != PVZSTD_OK) {
+    return st;
+  }
+
+  st = ParseContainer(reader.get(), file_version);
+  if (st != PVZSTD_OK) {
+    return st;
+  }
+
+  *out = reader.release();
+  return PVZSTD_OK;
+} catch (...) {
+  return PVZSTD_E_NOMEM;
+}
+
+pvzstd_status pvzstd_open_memory(const void *data, uint64_t size, pvzstd_reader **out) try {
+  return pvzstd_open_memory_versioned(data, size, out, nullptr);
 } catch (...) {
   return PVZSTD_E_NOMEM;
 }

--- a/cpp/src/reader.cpp
+++ b/cpp/src/reader.cpp
@@ -469,8 +469,11 @@ extern "C" {
 
 pvzstd_status pvzstd_open_versioned(const char *path, pvzstd_reader **out,
                                     uint32_t *file_version) try {
+  // Cleared before the argument check, not after: a refused open leaves *out at
+  // NULL on every path out of here, so a caller who did not initialise it is
+  // not left holding whatever was in that slot.
+  if (out != nullptr) *out = nullptr;
   if (path == nullptr || out == nullptr) return PVZSTD_E_INVALID;
-  *out = nullptr;
 
   // Owning: the parse below refuses the container on eleven paths and can throw
   // from a decompression sized by a field read out of the file, and every one of
@@ -502,8 +505,10 @@ pvzstd_status pvzstd_open(const char *path, pvzstd_reader **out) try {
 
 pvzstd_status pvzstd_open_memory_versioned(const void *data, uint64_t size, pvzstd_reader **out,
                                            uint32_t *file_version) try {
+  // As in pvzstd_open_versioned: cleared first, so a NULL `data` or a zero
+  // `size` leaves *out at NULL rather than untouched.
+  if (out != nullptr) *out = nullptr;
   if (data == nullptr || size == 0 || out == nullptr) return PVZSTD_E_INVALID;
-  *out = nullptr;
 
   std::unique_ptr<pvzstd_reader> reader(new (std::nothrow) pvzstd_reader());
   if (reader == nullptr) return PVZSTD_E_NOMEM;

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -8,11 +8,15 @@ Convenience Functions
 ``pyvista-zstd`` exposes two convenience functions to easily read and write compressed
 datasets to disk using `Zstandard <https://github.com/facebook/zstd>`_
 
+A container that is already in memory, rather than on disk, is read with
+:func:`pyvista_zstd.read_buffer`.
+
 
 .. autosummary::
    :toctree: _autosummary
 
    pyvista_zstd.read
+   pyvista_zstd.read_buffer
    pyvista_zstd.write
 
 

--- a/src/pyvista_zstd/__init__.py
+++ b/src/pyvista_zstd/__init__.py
@@ -17,6 +17,7 @@ from pyvista_zstd.pyvista_zstd import FILE_VERSION
 from pyvista_zstd.pyvista_zstd import Reader
 from pyvista_zstd.pyvista_zstd import Writer
 from pyvista_zstd.pyvista_zstd import read
+from pyvista_zstd.pyvista_zstd import read_buffer
 from pyvista_zstd.pyvista_zstd import write
 
 __all__ = [
@@ -27,5 +28,6 @@ __all__ = [
     "append_arrays",
     "read",
     "read_array",
+    "read_buffer",
     "write",
 ]

--- a/src/pyvista_zstd/_capi.py
+++ b/src/pyvista_zstd/_capi.py
@@ -50,7 +50,7 @@ __all__ = [
     "max_file_version",
 ]
 
-ABI_VERSION = 9
+ABI_VERSION = 10
 """ABI this binding speaks. A library reporting anything else is refused."""
 
 DTYPE_LEN = 16
@@ -254,6 +254,17 @@ def _bind_reader(lib: ctypes.CDLL) -> None:
     lib.pvzstd_open_versioned.restype = c_int
     lib.pvzstd_open_versioned.argtypes = [c_char_p, POINTER(c_void_p), POINTER(c_uint32)]
 
+    lib.pvzstd_open_memory.restype = c_int
+    lib.pvzstd_open_memory.argtypes = [c_void_p, c_uint64, POINTER(c_void_p)]
+
+    lib.pvzstd_open_memory_versioned.restype = c_int
+    lib.pvzstd_open_memory_versioned.argtypes = [
+        c_void_p,
+        c_uint64,
+        POINTER(c_void_p),
+        POINTER(c_uint32),
+    ]
+
     lib.pvzstd_max_file_version.restype = c_uint32
     lib.pvzstd_max_file_version.argtypes = []
 
@@ -442,10 +453,19 @@ class CoreReader:
     decompressed on demand. Reading two arrays out of a large file therefore
     costs two frames, not the whole file.
 
+    A container already resident is opened by passing ``buffer`` instead of
+    ``path``. The core borrows those bytes rather than copying them, so the
+    reader keeps a reference for as long as it is open and the caller must not
+    modify them meanwhile. Everything past the two opens is identical, refusals
+    for a damaged or crafted container included.
+
     Parameters
     ----------
-    path : pathlib.Path | str
+    path : pathlib.Path | str, optional
         Path to a ``.pv`` or ``.zvtk`` file.
+    buffer : bytes | bytearray | memoryview | numpy.ndarray, optional
+        A whole container, contiguous -- anything exposing the buffer protocol
+        without a copy. Exactly one of *path* and *buffer* is given.
 
     Examples
     --------
@@ -453,22 +473,55 @@ class CoreReader:
     >>> with _capi.CoreReader("dataset.pv") as reader:  # doctest: +SKIP
     ...     names = reader.names()
 
+    >>> from pathlib import Path
+    >>> raw = Path("dataset.pv").read_bytes()  # doctest: +SKIP
+    >>> with _capi.CoreReader(buffer=raw) as reader:  # doctest: +SKIP
+    ...     names = reader.names()
+
     """
 
-    def __init__(self, path: Path | str) -> None:
+    def __init__(
+        self,
+        path: Path | str | None = None,
+        *,
+        buffer: bytes | bytearray | memoryview | NDArray[Any] | None = None,
+    ) -> None:
         lib = _load()
         self._lib = lib
         self._handle: c_void_p | None = None
+        # Only a memory-backed reader holds one. The core borrows the bytes
+        # rather than owning them, so something on this side has to outlive it.
+        self._buffer: NDArray[np.uint8] | None = None
+
+        if (path is None) == (buffer is None):
+            msg = "CoreReader takes exactly one of `path` and `buffer`"
+            raise TypeError(msg)
 
         handle = c_void_p()
         # The versioned form so a refusal can name the version it refused; the
         # decision to refuse is the core's, and is already made by the time this
-        # returns.
+        # returns. Both opens report it, because a caller reading from memory
+        # needs the number for the same reason one reading a path does.
         found = c_uint32(0)
-        status = lib.pvzstd_open_versioned(str(path).encode("utf-8"), byref(handle), byref(found))
+        if path is not None:
+            detail = str(path)
+            status = lib.pvzstd_open_versioned(detail.encode("utf-8"), byref(handle), byref(found))
+        else:
+            # np.frombuffer does not copy, and the array it returns keeps
+            # whatever it was built from alive -- which is exactly the lifetime
+            # the core's borrowed pointer needs.
+            self._buffer = np.frombuffer(buffer, dtype=np.uint8)
+            detail = f"{self._buffer.nbytes}-byte buffer"
+            status = lib.pvzstd_open_memory_versioned(
+                c_void_p(self._buffer.ctypes.data),
+                c_uint64(self._buffer.nbytes),
+                byref(handle),
+                byref(found),
+            )
+
         if status == _STATUS_VERSION:
             raise UnsupportedFileVersionError(int(found.value), int(lib.pvzstd_max_file_version()))
-        _check(status, str(path))
+        _check(status, detail)
         self._handle = handle
 
     # PYI034 wants `Self`, which is 3.11+; this package supports 3.10.
@@ -485,6 +538,10 @@ class CoreReader:
         if self._handle is not None:
             self._lib.pvzstd_close(self._handle)
             self._handle = None
+        # Dropped only now: the core read out of these bytes until the close
+        # above, and a memory-backed reader is the only thing keeping the
+        # caller's buffer from being collected.
+        self._buffer = None
 
     def __del__(self) -> None:
         """Release the C++ reader if the caller forgot to."""

--- a/src/pyvista_zstd/_capi.py
+++ b/src/pyvista_zstd/_capi.py
@@ -456,8 +456,12 @@ class CoreReader:
     A container already resident is opened by passing ``buffer`` instead of
     ``path``. The core borrows those bytes rather than copying them, so the
     reader keeps a reference for as long as it is open and the caller must not
-    modify them meanwhile. Everything past the two opens is identical, refusals
-    for a damaged or crafted container included.
+    modify them meanwhile. A write into them is not detected -- the offsets and
+    sizes were read at open time, so the arrays read afterwards hold undefined
+    contents with no error to say so. A resize is: the borrow pins the buffer,
+    and resizing it raises :class:`BufferError` rather than corrupting
+    anything. Everything past the two opens is identical, refusals for a
+    damaged or crafted container included.
 
     Parameters
     ----------

--- a/src/pyvista_zstd/pyvista_zstd.py
+++ b/src/pyvista_zstd/pyvista_zstd.py
@@ -1034,7 +1034,10 @@ def read_buffer(data: bytes | bytearray | memoryview | NDArray[Any], n_threads: 
 
     :func:`read` for bytes rather than a path -- an archive member, a response
     body, or a build with no filesystem to open a path on. The bytes are
-    borrowed, not copied, and must not be modified while the read is running.
+    borrowed, not copied, and must not be modified while the read is running:
+    a write into them is not detected, so the dataset comes back with undefined
+    contents and no error to say so. A resize is detected, and raises
+    :class:`BufferError` rather than corrupting anything.
 
     This is a convenience function that uses :class:`Reader`. Use that class to
     finely tune reading.
@@ -1162,6 +1165,10 @@ class Reader:
     ``filename`` -- an archive member, a response body, or a build with no
     filesystem to open a path on. Those bytes are borrowed rather than copied
     and are held for the reader's life, so they must not be modified meanwhile.
+    Writing into them is not detected: the arrays read afterwards hold
+    undefined contents, and no error is raised to say so. Resizing them is
+    detected -- the borrow pins the buffer, so a resize raises
+    :class:`BufferError` rather than corrupting anything.
 
     Parameters
     ----------

--- a/src/pyvista_zstd/pyvista_zstd.py
+++ b/src/pyvista_zstd/pyvista_zstd.py
@@ -1028,6 +1028,38 @@ def read(
     return Reader(filename).read(n_threads=n_threads)
 
 
+def read_buffer(data: bytes | bytearray | memoryview | NDArray[Any], n_threads: int | None = None) -> DataSet:
+    """
+    Decompress a ``pyvista-zstd`` container already held in memory.
+
+    :func:`read` for bytes rather than a path -- an archive member, a response
+    body, or a build with no filesystem to open a path on. The bytes are
+    borrowed, not copied, and must not be modified while the read is running.
+
+    This is a convenience function that uses :class:`Reader`. Use that class to
+    finely tune reading.
+
+    Parameters
+    ----------
+    data : bytes | bytearray | memoryview | numpy.ndarray
+        A whole ``.pv`` or ``.zvtk`` container, contiguous.
+    n_threads : None | int, optional
+        Workers to spread the frames over, exactly as in :func:`read`.
+
+    Returns
+    -------
+    pyvista.DataSet
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> import pyvista_zstd
+    >>> ds = pyvista_zstd.read_buffer(Path("dataset.pv").read_bytes())
+
+    """
+    return Reader(buffer=data).read(n_threads=n_threads)
+
+
 class _DataSetReader:
     def __init__(
         self,
@@ -1126,10 +1158,21 @@ class Reader:
     * For files containing a :class:`pyvista.MultiBlock`, select which blocks
       to read in.
 
+    A container already resident is read by passing ``buffer`` instead of
+    ``filename`` -- an archive member, a response body, or a build with no
+    filesystem to open a path on. Those bytes are borrowed rather than copied
+    and are held for the reader's life, so they must not be modified meanwhile.
+
     Parameters
     ----------
-    filename : pathlib.Path | str
+    filename : pathlib.Path | str, optional
         Path to the file. Must end in ``.pv``.
+    buffer : bytes | bytearray | memoryview | numpy.ndarray, optional
+        A whole container, contiguous. Exactly one of *filename* and *buffer*
+        is given; a buffer has no suffix to check, so its bytes decide whether
+        it is a container.
+    backend : str, optional
+        Deprecated and ignored; passing it raises a :class:`DeprecationWarning`.
 
     Examples
     --------
@@ -1169,12 +1212,19 @@ class Reader:
       Z Bounds:   -5.000e-01, 5.000e-01
       N Arrays:   0
 
+    Read the same container out of memory instead of off disk.
+
+    >>> from pathlib import Path
+    >>> raw = Path("sphere.pv").read_bytes()
+    >>> ds_in = pyvista_zstd.Reader(buffer=raw).read()
+
     """
 
     def __init__(
         self,
-        filename: Path | str,
+        filename: Path | str | None = None,
         *,
+        buffer: bytes | bytearray | memoryview | NDArray[Any] | None = None,
         backend: str | None = None,
     ) -> None:
         """
@@ -1183,13 +1233,19 @@ class Reader:
         ``backend`` is deprecated and ignored.
         """
         _warn_backend_deprecated(backend)
-        self._filename = Path(filename)
+        if (filename is None) == (buffer is None):
+            msg = "Reader takes exactly one of `filename` and `buffer`"
+            raise TypeError(msg)
+
+        self._filename = None if filename is None else Path(filename)
+        self._buffer = buffer
         self._selected_point_arrays: set[str] | None = None
         self._selected_cell_arrays: set[str] | None = None
         self._selected_field_arrays: set[str] | None = None
         self._core: CoreReader | None = None
 
-        if self._filename.suffix not in SUPPORTED_READ_SUFFIXES:
+        # Only a path carries a suffix to judge; a buffer is judged by its bytes.
+        if self._filename is not None and self._filename.suffix not in SUPPORTED_READ_SUFFIXES:
             msg = f"Filename must end in one of {SUPPORTED_READ_SUFFIXES}, not '{self._filename.suffix}'"
             raise ValueError(msg)
 
@@ -1197,7 +1253,7 @@ class Reader:
             core = self._core_reader()
         except _capi.ContainerFormatError as err:
             # Callers catch on this wording, so keep it.
-            msg = f"'{self._filename}' did not parse as a pyvista-zstd container. File may be corrupted."
+            msg = f"'{self._source}' did not parse as a pyvista-zstd container. File may be corrupted."
             raise RuntimeError(msg) from err
         self._frame_decompressed, self._compressed_sizes = core.frame_sizes()
         self._metadata_documents = dict(core.metadata_documents())
@@ -1206,6 +1262,11 @@ class Reader:
         self._ds_metadata = self._root_ds_meta_from_core()
 
         self.__ds_reader: _DataSetReader | None = None
+
+    @property
+    def _source(self) -> str:
+        """Name this container came under, for messages and for the repr."""
+        return "<memory>" if self._filename is None else str(self._filename)
 
     def __getitem__(self, idx: int) -> _DataSetReader:
         """Return an indexed reader."""
@@ -1276,7 +1337,7 @@ class Reader:
             # end users re-saving their data files, and Python's default
             # warning filters hide DeprecationWarning from non-__main__ code.
             warnings.warn(
-                f"'{self._filename}' is a legacy zvtk file. Support for the "
+                f"'{self._source}' is a legacy zvtk file. Support for the "
                 "'.zvtk' format will be removed in a future release; re-save "
                 "it with `pyvista_zstd.write(pyvista_zstd.read(path), new_path)`.",
                 FutureWarning,
@@ -1320,10 +1381,12 @@ class Reader:
 
     def _core_reader(self) -> CoreReader:
         """
-        Return the C++ reader for this file, opened once and kept.
+        Return the C++ reader for this container, opened once and kept.
 
-        Opening one maps the file and parses the trailer and every array
-        header. This object did all of that in __init__ already, so building a
+        Opening one takes the container's bytes -- mapping the file, or
+        borrowing the buffer :meth:`from_buffer` was given -- and parses the
+        trailer and every array header. This object did all of that already at
+        construction, so building a
         fresh C++ reader per dataset paid for a second copy of it on every
         read -- and a MultiBlock paid once per dataset.
 
@@ -1334,7 +1397,7 @@ class Reader:
         """
         reader = self._core
         if reader is None:
-            reader = _capi.CoreReader(self._filename)
+            reader = _capi.CoreReader(self._filename) if self._buffer is None else _capi.CoreReader(buffer=self._buffer)
             self._core = reader
         return reader
 
@@ -1673,7 +1736,7 @@ class Reader:
         ds_md = self._ds_metadata
         header = [
             f"pyvista_zstd.Reader ({hex(id(self))})",
-            f"  File:               {self._filename}",
+            f"  File:               {self._source}",
             f"  File Version:       {self._metadata.file_version}",
             f"  Compression:        {self._metadata.compression}",
             f"  Compression Level:  {self._metadata.compression_level}",

--- a/src/pyvista_zstd/pyvista_zstd.py
+++ b/src/pyvista_zstd/pyvista_zstd.py
@@ -1025,7 +1025,8 @@ def read(
     if has_scheme is not None and has_scheme(str(filename)):
         raise LocalFileRequiredError
     _warn_backend_deprecated(backend)
-    return Reader(filename).read(n_threads=n_threads)
+    with Reader(filename) as reader:
+        return reader.read(n_threads=n_threads)
 
 
 def read_buffer(data: bytes | bytearray | memoryview | NDArray[Any], n_threads: int | None = None) -> DataSet:
@@ -1060,7 +1061,10 @@ def read_buffer(data: bytes | bytearray | memoryview | NDArray[Any], n_threads: 
     >>> ds = pyvista_zstd.read_buffer(Path("dataset.pv").read_bytes())
 
     """
-    return Reader(buffer=data).read(n_threads=n_threads)
+    # Closed on the way out, so the caller's bytes stop being borrowed as soon
+    # as the arrays are built rather than whenever the reader is collected.
+    with Reader(buffer=data) as reader:
+        return reader.read(n_threads=n_threads)
 
 
 class _DataSetReader:
@@ -1170,6 +1174,14 @@ class Reader:
     detected -- the borrow pins the buffer, so a resize raises
     :class:`BufferError` rather than corrupting anything.
 
+    A reader holds the file mapped, or the caller's buffer alive, until
+    :meth:`close` -- which ``with`` calls on the way out:
+
+    .. code-block:: python
+
+        with pyvista_zstd.Reader(buffer=raw) as reader:
+            ds = reader.read()
+
     Parameters
     ----------
     filename : pathlib.Path | str, optional
@@ -1250,6 +1262,7 @@ class Reader:
         self._selected_cell_arrays: set[str] | None = None
         self._selected_field_arrays: set[str] | None = None
         self._core: CoreReader | None = None
+        self._closed = False
 
         # Only a path carries a suffix to judge; a buffer is judged by its bytes.
         if self._filename is not None and self._filename.suffix not in SUPPORTED_READ_SUFFIXES:
@@ -1269,6 +1282,31 @@ class Reader:
         self._ds_metadata = self._root_ds_meta_from_core()
 
         self.__ds_reader: _DataSetReader | None = None
+
+    # PYI034 wants `Self`, which is 3.11+; this package supports 3.10.
+    def __enter__(self) -> Reader:  # noqa: PYI034
+        """Return self; the reader is already open."""
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        """Release the container, as :meth:`close` does."""
+        self.close()
+
+    def close(self) -> None:
+        """
+        Release the container. Safe to call more than once.
+
+        Unmaps the file, or drops the reference to the buffer this reader was
+        given -- which, until now, has kept those bytes alive on the caller's
+        behalf. Reading anything afterwards raises :class:`ValueError`; the
+        metadata taken when the container was opened stays readable, because it
+        was copied out then and no longer touches the container.
+        """
+        if self._core is not None:
+            self._core.close()
+            self._core = None
+        self._buffer = None
+        self._closed = True
 
     @property
     def _source(self) -> str:
@@ -1391,17 +1429,20 @@ class Reader:
         Return the C++ reader for this container, opened once and kept.
 
         Opening one takes the container's bytes -- mapping the file, or
-        borrowing the buffer :meth:`from_buffer` was given -- and parses the
-        trailer and every array header. This object did all of that already at
-        construction, so building a
+        borrowing the buffer the ``buffer`` argument was given -- and parses
+        the trailer and every array header. This object did all of that already
+        at construction, so building a
         fresh C++ reader per dataset paid for a second copy of it on every
         read -- and a MultiBlock paid once per dataset.
 
         Holding it does not weaken any guarantee that was being offered: the
         frame index and the mapping are both taken in __init__ and kept, so a
         reader has always been a snapshot of the file as it was when opened.
-        It is released when this object is, the same way the mapping is.
+        It is released by :meth:`close`, or when this object is collected.
         """
+        if self._closed:
+            msg = "operation on a closed Reader"
+            raise ValueError(msg)
         reader = self._core
         if reader is None:
             reader = _capi.CoreReader(self._filename) if self._buffer is None else _capi.CoreReader(buffer=self._buffer)

--- a/tests/conformance/test_open_memory.py
+++ b/tests/conformance/test_open_memory.py
@@ -40,6 +40,10 @@ STATUS_INVALID = 7
 # sees a tiny index and accepts the file.
 POISON_FRAME_COUNT = 2**60 + 2
 
+# Written into an out-parameter before a call that must refuse, so the assert
+# that it came back NULL is about the callee and not about ctypes' zeroing.
+POISON_HANDLE = 0xDEADBEEF
+
 
 def _dataset() -> pv.DataSet:
     rng = np.random.default_rng(11)
@@ -195,11 +199,39 @@ def test_a_zero_size_buffer_is_invalid() -> None:
 def test_a_null_pointer_is_invalid() -> None:
     """NULL with a plausible size must be refused, not dereferenced."""
     lib = _capi._load()  # noqa: SLF001
-    handle = ctypes.c_void_p()
+    # Poisoned, not zeroed: ctypes zero-initialises, so a handle left at its
+    # default would pass whether or not the refusal cleared it.
+    handle = ctypes.c_void_p(POISON_HANDLE)
     status = lib.pvzstd_open_memory(None, ctypes.c_uint64(1024), ctypes.byref(handle))
 
     assert int(status) == STATUS_INVALID
-    assert handle.value is None
+    assert handle.value is None, "a refused open left *out holding what the caller had there"
+
+
+def test_every_refusal_leaves_the_out_pointer_at_null() -> None:
+    """
+    Both doors clear *out before deciding, so no refusal hands back a stale value.
+
+    A caller who checks the handle rather than the status -- or who reuses one
+    across two opens -- otherwise reads whatever was in that slot.
+    """
+    lib = _capi._load()  # noqa: SLF001
+    raw = np.frombuffer(b"not a container", dtype=np.uint8)
+    data = ctypes.c_void_p(raw.ctypes.data)
+
+    # A NULL pointer, a zero size, and bytes that are not a container, through
+    # the memory door; a NULL path and a missing file through the file door.
+    refusals = {
+        "null data": (lib.pvzstd_open_memory, (None, ctypes.c_uint64(1024))),
+        "zero size": (lib.pvzstd_open_memory, (data, ctypes.c_uint64(0))),
+        "not a container": (lib.pvzstd_open_memory, (data, ctypes.c_uint64(raw.nbytes))),
+        "null path": (lib.pvzstd_open, (None,)),
+        "missing file": (lib.pvzstd_open, (b"no/such/container.pv",)),
+    }
+    for case, (entry, args) in refusals.items():
+        handle = ctypes.c_void_p(POISON_HANDLE)
+        assert int(entry(*args, ctypes.byref(handle))) != _capi._STATUS_OK, case  # noqa: SLF001
+        assert handle.value is None, case
 
 
 def test_a_null_out_pointer_is_invalid() -> None:

--- a/tests/conformance/test_open_memory.py
+++ b/tests/conformance/test_open_memory.py
@@ -103,6 +103,21 @@ def test_the_same_container_reads_identically_from_a_path_and_from_memory(contai
         assert np.array_equal(left_compressed, right_compressed)
 
 
+def test_the_dataset_read_out_of_memory_matches_the_one_written(container: Path) -> None:
+    """The public read reaches the same dataset through bytes as through a path."""
+    from_path = pz.read(container)
+    from_memory = pz.read_buffer(container.read_bytes())
+
+    assert type(from_path) is type(from_memory)
+    assert np.array_equal(from_path.points, from_memory.points)
+    for attr in ("point_data", "cell_data", "field_data"):
+        left, right = getattr(from_path, attr), getattr(from_memory, attr)
+        assert set(left.keys()) == set(right.keys()), attr
+        for key in left:
+            assert left[key].dtype == right[key].dtype, (attr, key)
+            assert np.array_equal(left[key], right[key]), (attr, key)
+
+
 def test_the_reader_survives_the_bytes_object_going_out_of_scope(container: Path) -> None:
     """The reader holds the buffer, so a caller dropping its own name is safe."""
     reader = _capi.CoreReader(buffer=container.read_bytes())
@@ -227,3 +242,26 @@ def test_the_core_reader_takes_exactly_one_source(container: Path) -> None:
         _capi.CoreReader()
     with pytest.raises(TypeError):
         _capi.CoreReader(container, buffer=container.read_bytes())
+
+
+def test_the_public_reader_takes_exactly_one_source(container: Path) -> None:
+    """The same rule at the public surface, so neither layer guesses."""
+    with pytest.raises(TypeError):
+        pz.Reader()
+    with pytest.raises(TypeError):
+        pz.Reader(container, buffer=container.read_bytes())
+
+
+def test_a_buffer_is_judged_by_its_bytes_and_not_by_a_suffix(container: Path) -> None:
+    """
+    The suffix check belongs to the path, not to the container.
+
+    A path ending in something else is refused before anything is read; a
+    buffer has no name to refuse, so what it holds has to decide.
+    """
+    with pytest.raises(ValueError, match="Filename must end in"):
+        pz.Reader(container.with_suffix(".txt"))
+
+    assert pz.Reader(buffer=container.read_bytes()) is not None
+    with pytest.raises(RuntimeError, match="File may be corrupted"):
+        pz.Reader(buffer=b"not a container at all, but it is bytes")

--- a/tests/conformance/test_open_memory.py
+++ b/tests/conformance/test_open_memory.py
@@ -19,8 +19,10 @@ Requires the core, and does not skip without it -- as
 from __future__ import annotations
 
 import ctypes
+import gc
 import struct
 from typing import TYPE_CHECKING
+import weakref
 
 import numpy as np
 import pytest
@@ -297,3 +299,60 @@ def test_a_buffer_is_judged_by_its_bytes_and_not_by_a_suffix(container: Path) ->
     assert pz.Reader(buffer=container.read_bytes()) is not None
     with pytest.raises(RuntimeError, match="File may be corrupted"):
         pz.Reader(buffer=b"not a container at all, but it is bytes")
+
+
+def test_a_reader_closes_and_stays_closed(container: Path) -> None:
+    """Both doors take a close, and a second one is not an error."""
+    for reader in (pz.Reader(container), pz.Reader(buffer=container.read_bytes())):
+        assert reader.read().n_points
+        reader.close()
+        reader.close()
+
+        with pytest.raises(ValueError, match="closed Reader"):
+            reader.read()
+
+
+def test_the_reader_is_a_context_manager(container: Path) -> None:
+    """``with`` closes on the way out, through either door."""
+    with pz.Reader(container) as by_path:
+        from_path = by_path.read()
+    with pz.Reader(buffer=container.read_bytes()) as by_memory:
+        from_memory = by_memory.read()
+
+    assert np.array_equal(from_path.points, from_memory.points)
+    for reader in (by_path, by_memory):
+        with pytest.raises(ValueError, match="closed Reader"):
+            reader.read()
+
+
+def test_closing_lets_go_of_the_buffer_the_caller_handed_over(container: Path) -> None:
+    """
+    The point of closing a memory-backed reader: the caller's bytes are freed.
+
+    A reader kept in a list -- one per response body -- otherwise pins every
+    one of those bodies for as long as the list lives.
+    """
+    raw = np.frombuffer(container.read_bytes(), dtype=np.uint8).copy()
+    witness = weakref.ref(raw)
+
+    reader = pz.Reader(buffer=raw)
+    assert reader.read().n_points
+    del raw
+    assert witness() is not None, "the reader must hold the bytes while it is open"
+
+    reader.close()
+    gc.collect()
+    assert witness() is None, "a closed reader still holds the caller's buffer"
+
+
+def test_a_buffer_cannot_be_resized_under_an_open_reader(container: Path) -> None:
+    """The borrow pins the buffer, so a resize is refused rather than followed."""
+    raw = bytearray(container.read_bytes())
+
+    with pz.Reader(buffer=raw) as reader:
+        assert reader.read().n_points
+        with pytest.raises(BufferError):
+            raw.extend(b"\0" * 64)
+
+    # Closing gives the bytes back, resizable again.
+    raw.extend(b"\0" * 64)

--- a/tests/conformance/test_open_memory.py
+++ b/tests/conformance/test_open_memory.py
@@ -1,0 +1,229 @@
+"""
+Reading a container out of memory must be the same read as reading the file.
+
+The memory entry point exists for callers with no path to open -- an archive
+member, a response body, a build with no filesystem -- so what matters is that
+it is the *same* reader, not a second one: identical bytes out of identical
+containers, and identical refusals for containers that are damaged or crafted.
+
+The safety cases are written against the memory entry point on purpose. Every
+one of them is a check the file path already makes, and a buffer reaches the
+parse by a different door; a guard that only the file door passes through is
+an out-of-bounds read waiting for a caller who has the bytes rather than a
+path.
+
+Requires the core, and does not skip without it -- as
+``test_cpp_reader_roundtrip`` does, and for the same reason.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import struct
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+import pyvista as pv
+
+import pyvista_zstd as pz
+from pyvista_zstd import _capi
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# Mirrors PVZSTD_E_INVALID. Nothing else in this module needs a status by name.
+STATUS_INVALID = 7
+
+# Even (frames pair as header/payload) and large enough that n_frames * 16
+# wraps a uint64 back to 32 -- so a guard that multiplies before comparing
+# sees a tiny index and accepts the file.
+POISON_FRAME_COUNT = 2**60 + 2
+
+
+def _dataset() -> pv.DataSet:
+    rng = np.random.default_rng(11)
+    ds = pv.Sphere(theta_resolution=14, phi_resolution=14)
+    ds.point_data["scal_f64"] = rng.random(ds.n_points)
+    ds.point_data["vec_f32"] = rng.random((ds.n_points, 3)).astype(np.float32)
+    ds.cell_data["ids_i64"] = np.arange(ds.n_cells, dtype=np.int64)
+    ds.field_data["note_i32"] = np.arange(4, dtype=np.int32)
+    return ds
+
+
+@pytest.fixture
+def container(tmp_path: Path) -> Path:
+    """Write a single-dataset container and return its path."""
+    path = tmp_path / "memory.pv"
+    pz.write(_dataset(), path, shuffle=True, progress_bar=False)
+    return path
+
+
+def _open_memory(raw: bytes) -> int:
+    """Call pvzstd_open_memory on *raw* and return the status, closing on success."""
+    lib = _capi._load()  # noqa: SLF001
+    handle = ctypes.c_void_p()
+    buffer = np.frombuffer(raw, dtype=np.uint8)
+    status = lib.pvzstd_open_memory(
+        ctypes.c_void_p(buffer.ctypes.data),
+        ctypes.c_uint64(buffer.nbytes),
+        ctypes.byref(handle),
+    )
+    if status == _capi._STATUS_OK:  # noqa: SLF001
+        lib.pvzstd_close(handle)
+    assert handle.value is None or status == _capi._STATUS_OK, (  # noqa: SLF001
+        "a refused open must leave *out at NULL"
+    )
+    return int(status)
+
+
+def test_the_same_container_reads_identically_from_a_path_and_from_memory(container: Path) -> None:
+    """Every array's bytes and every metadata document agree between the two."""
+    raw = container.read_bytes()
+
+    with _capi.CoreReader(container) as by_path, _capi.CoreReader(buffer=raw) as by_memory:
+        assert by_path.names() == by_memory.names()
+        assert by_path.names(), "a container with no arrays would pass this vacuously"
+
+        for index in range(len(by_path)):
+            left = by_path.read_at(index)
+            right = by_memory.read_at(index)
+            assert left.dtype == right.dtype, by_path.names()[index]
+            assert left.shape == right.shape, by_path.names()[index]
+            assert left.tobytes() == right.tobytes(), by_path.names()[index]
+
+        assert by_path.metadata_documents() == by_memory.metadata_documents()
+        assert by_path.ds_metadata_json == by_memory.ds_metadata_json
+        assert by_path.file_metadata_json == by_memory.file_metadata_json
+        assert by_path.field_array_names() == by_memory.field_array_names()
+
+        left_sizes, left_compressed = by_path.frame_sizes()
+        right_sizes, right_compressed = by_memory.frame_sizes()
+        assert np.array_equal(left_sizes, right_sizes)
+        assert np.array_equal(left_compressed, right_compressed)
+
+
+def test_the_reader_survives_the_bytes_object_going_out_of_scope(container: Path) -> None:
+    """The reader holds the buffer, so a caller dropping its own name is safe."""
+    reader = _capi.CoreReader(buffer=container.read_bytes())
+    names = reader.names()
+    assert names
+
+    # Nothing else refers to those bytes now. The core borrows rather than
+    # owning, so a reader that did not keep them would read freed memory here.
+    for index in range(len(reader)):
+        assert reader.read_at(index).nbytes >= 0
+    reader.close()
+
+
+def test_a_truncated_buffer_is_refused(container: Path) -> None:
+    """Cutting the trailer off leaves bytes that must not parse."""
+    raw = container.read_bytes()
+    ok = _capi._STATUS_OK  # noqa: SLF001
+    assert _open_memory(raw) == ok, "the control case must open, or the prefixes prove nothing"
+
+    # Shorter than the trailer count, cut inside the index, and cut just short
+    # of the trailer: the three ways the bytes can run out.
+    for keep in (4, len(raw) - 32, len(raw) - 8):
+        assert _open_memory(raw[:keep]) != ok, f"a {keep}-byte prefix of a container was accepted"
+
+
+def test_an_absurd_frame_count_is_refused_rather_than_multiplied(container: Path) -> None:
+    """
+    The frame-count guard divides, so a count that overflows the multiply fails.
+
+    ``2**60 + 2`` entries of 16 bytes wrap a uint64 to 32, which a guard
+    written as ``n_frames * 16 > available`` would wave through and then index
+    a megabyte-sized buffer with.
+    """
+    raw = bytearray(container.read_bytes())
+    raw[-8:] = struct.pack("<Q", POISON_FRAME_COUNT)
+
+    assert _open_memory(bytes(raw)) == _capi._STATUS_FORMAT, (  # noqa: SLF001
+        "a frame count whose index would not fit in the container was accepted"
+    )
+
+
+def test_a_header_whose_declared_size_disagrees_with_its_shape_is_refused(tmp_path: Path) -> None:
+    """
+    A payload size that does not follow from shape and dtype is a buffer overrun.
+
+    Reads honour the declared size while callers size destinations from shape
+    and dtype, so the two disagreeing is the file telling the reader to write
+    past the end of the caller's array.
+    """
+    path = tmp_path / "declared.pv"
+    ds = pv.Sphere(theta_resolution=8, phi_resolution=8)
+    ds.point_data["scal_f64"] = np.arange(ds.n_points, dtype=np.float64)
+    pz.write(ds, path, progress_bar=False)
+
+    raw = bytearray(path.read_bytes())
+    # The trailer's index entries are (end offset, decompressed size) pairs; the
+    # payload frames are the odd ones. Doubling one payload's declared size
+    # leaves it disagreeing with the shape and dtype in its header.
+    (n_frames,) = struct.unpack("<Q", raw[-8:])
+    index_off = len(raw) - 8 - n_frames * 16
+    size_off = index_off + 16 + 8  # frame 1 is the first payload
+    (declared,) = struct.unpack("<Q", raw[size_off : size_off + 8])
+    raw[size_off : size_off + 8] = struct.pack("<Q", declared * 2)
+
+    assert _open_memory(bytes(raw)) != _capi._STATUS_OK, (  # noqa: SLF001
+        "a payload size disagreeing with its header's shape and dtype was accepted"
+    )
+
+
+def test_a_zero_size_buffer_is_invalid() -> None:
+    """Zero bytes is not a container, and is a misuse rather than a bad file."""
+    assert _open_memory(b"") == STATUS_INVALID
+
+
+def test_a_null_pointer_is_invalid() -> None:
+    """NULL with a plausible size must be refused, not dereferenced."""
+    lib = _capi._load()  # noqa: SLF001
+    handle = ctypes.c_void_p()
+    status = lib.pvzstd_open_memory(None, ctypes.c_uint64(1024), ctypes.byref(handle))
+
+    assert int(status) == STATUS_INVALID
+    assert handle.value is None
+
+
+def test_a_null_out_pointer_is_invalid() -> None:
+    """Nowhere to put the reader is a misuse too, and must not be written to."""
+    lib = _capi._load()  # noqa: SLF001
+    raw = np.frombuffer(b"not a container", dtype=np.uint8)
+    status = lib.pvzstd_open_memory(ctypes.c_void_p(raw.ctypes.data), ctypes.c_uint64(raw.nbytes), None)
+
+    assert int(status) == STATUS_INVALID
+
+
+def test_the_versioned_form_reports_the_file_version(container: Path) -> None:
+    """A memory open names the container's version, as the file open does."""
+    lib = _capi._load()  # noqa: SLF001
+    raw = np.frombuffer(container.read_bytes(), dtype=np.uint8)
+
+    from_memory = ctypes.c_uint32(0)
+    handle = ctypes.c_void_p()
+    status = lib.pvzstd_open_memory_versioned(
+        ctypes.c_void_p(raw.ctypes.data),
+        ctypes.c_uint64(raw.nbytes),
+        ctypes.byref(handle),
+        ctypes.byref(from_memory),
+    )
+    assert status == _capi._STATUS_OK  # noqa: SLF001
+    lib.pvzstd_close(handle)
+
+    from_path = ctypes.c_uint32(0)
+    handle = ctypes.c_void_p()
+    status = lib.pvzstd_open_versioned(str(container).encode("utf-8"), ctypes.byref(handle), ctypes.byref(from_path))
+    assert status == _capi._STATUS_OK  # noqa: SLF001
+    lib.pvzstd_close(handle)
+
+    assert from_memory.value == from_path.value
+
+
+def test_the_core_reader_takes_exactly_one_source(container: Path) -> None:
+    """Neither source, or both, is a misuse rather than a silent preference."""
+    with pytest.raises(TypeError):
+        _capi.CoreReader()
+    with pytest.raises(TypeError):
+        _capi.CoreReader(container, buffer=container.read_bytes())


### PR DESCRIPTION
`pvzstd_open` only ever took a path, so there was no way to read a container the caller already holds: an archive member, an HTTP response body, a test fixture, or anything in a WebAssembly build linked with `-sFILESYSTEM=0`, where there is no path to open and no filesystem to stage bytes into.

Resolves #39.

```c
pvzstd_status pvzstd_open_memory(const void *data, uint64_t size, pvzstd_reader **out);
pvzstd_status pvzstd_open_memory_versioned(const void *data, uint64_t size,
                                           pvzstd_reader **out, uint32_t *file_version);
```

The versioned form is not there for symmetry alone. `CoreReader` opens through it so a refusal can name the `file_version` it refused, and a memory reader without one would report a worse error than the file reader does for the same container.

ABI version moves 9 to 10.

## How it reaches the reader

`FileMapping` became `ContainerBytes` with a `Borrow(data, size)` that marks the view non-owning, and `Reset()` returns early for a borrowed range, so closing a memory-backed reader unmaps and closes nothing it does not own. Nothing is copied; the caller owns the buffer for the reader's lifetime.

Everything downstream of obtaining the byte range moved out of `pvzstd_open_versioned` into one `ParseContainer`, which both doors call. That is what makes the validation claim structural rather than a promise: the trailer bounds check, the divide-first frame-count guard and the declared-size-versus-shape check are in the shared path, so a crafted buffer meets exactly what a crafted file meets. The moved body is otherwise unchanged, and `pvzstd_open` keeps its status codes, its `*out` handling, its error text and its deliberate file-handle release.

Two safety checks were reviewed against crafted input on both a 64-bit build under ASan and UBSan and an Emscripten build: truncated buffers, a trailer frame count of `2**60 + 2`, a doubled declared payload size, zero size, and a null pointer. Each returns a status and leaves `*out` null.

Separately, `pvzstd_open_versioned` had an ordering bug where `*out` was left untouched on an argument refusal. Both doors now clear it before the argument check, and the test writes a poison value into the handle first so it cannot pass on a zero-initialised one.

## Python

`Reader(buffer=...)` and `pyvista_zstd.read_buffer(data)`, one constructor per class taking exactly one source rather than a parallel path.

`Reader` gained `close()` and the context-manager protocol, following `CoreReader`, which already had both. Without them the class held the caller's bytes for its whole life with no way to end that life: a loop of `Reader(buffer=response.content)` kept in a list pinned every response body until collection. `read()` and `read_buffer()` now use `with`, so the one-shot functions release promptly. A closed reader raises rather than reaching the core.

The documentation says what modifying the buffer under an open reader actually does, in the header and on the Python side, because the failure is silent. Resizing a `bytearray` raises `BufferError`, since `np.frombuffer` pins it. Mutating in place is permitted, the view sees it, and offsets were cached at open, so a payload edited mid-read comes back as plausible wrong values with `PVZSTD_OK`. Both behaviours were confirmed against the built library rather than assumed.

One asymmetry is documented rather than smoothed over: a zero-length container is `PVZSTD_E_IO` through `pvzstd_open` and `PVZSTD_E_INVALID` through `pvzstd_open_memory`. A zero size is a bad argument; a zero-length file is a property of the thing opened. Changing a long-standing status on an existing entry point to tidy a new one seemed the worse trade.

`read_array` and `append_arrays` stay path-only for now.

## Verified without a filesystem

Built for wasm with emsdk 4.0.20, `PVZSTD_BUILD_SHARED=OFF PVZSTD_THREADS=OFF`, linked into a throwaway program with `-sFILESYSTEM=0`. A container copied into the wasm heap reads back byte-identical to the host `pvzstd_dump`, matching FNV per payload. In the same binary `pvzstd_open` on a path returns `PVZSTD_E_IO`, because there is no filesystem behind it.
