### PR TITLE
Refuse crafted container fields the WASM build could not survive

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -136,6 +136,31 @@ else()
   target_compile_options(pvzstd PRIVATE -Wall -Wextra)
 endif()
 
+# --- Exceptions on WebAssembly ------------------------------------------
+#
+# Every extern "C" entry point is a function-try-block ending in catch(...),
+# which is how the header can promise a status code rather than an exception
+# unwinding into a C caller. Emscripten defaults to
+# -sDISABLE_EXCEPTION_CATCHING=1, which compiles every one of those handlers
+# away and turns a throw into abort() -- so on that target the promise the
+# header makes is not kept, and a caller parsing untrusted input gets a dead
+# process instead of PVZSTD_E_NOMEM.
+#
+# -fwasm-exceptions rather than -sNO_DISABLE_EXCEPTION_CATCHING: the latter is
+# the legacy JavaScript-based unwinder, which is slower, larger, and taxes
+# every call site whether or not anything throws, while the former lowers to
+# the WebAssembly exception-handling instructions that every engine emsdk
+# 4.0.20 targets already implements. It is needed at compile and at link.
+#
+# PUBLIC, not PRIVATE: a wasm link cannot mix exception models, so a consumer
+# compiling its own translation units against this library and then linking it
+# has to be on the same one. Scoped to the target rather than set globally, so
+# a project that embeds this library keeps its own flags everywhere else.
+if(EMSCRIPTEN)
+  target_compile_options(pvzstd PUBLIC -fwasm-exceptions)
+  target_link_options(pvzstd PUBLIC -fwasm-exceptions)
+endif()
+
 if(PVZSTD_THREADS)
   find_package(Threads REQUIRED)
   target_link_libraries(pvzstd PRIVATE Threads::Threads)

--- a/cpp/src/reader.cpp
+++ b/cpp/src/reader.cpp
@@ -6,6 +6,7 @@
 
 #include <zstd.h>
 
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <memory>
@@ -40,6 +41,31 @@ constexpr char kLegacyFileMetadataSuffix[] = "__zvtk_metadata";
 constexpr char kMultiblockSuffix[] = "__multiblock__ds_metadata";
 constexpr char kFieldDataSuffix[] = "__field_data";
 constexpr size_t kUidNChar = 16;
+
+// Whether a 64-bit field out of the container is too large to be held in a
+// size_t. Always false where size_t is 64 bits; on a 32-bit target -- and a
+// WebAssembly build is one -- it is what stops a file-supplied length from
+// wrapping as it is narrowed, or from being silently truncated into a smaller
+// allocation than the value the rest of the parse is still reasoning about.
+constexpr bool ExceedsSizeT(uint64_t v) {
+  if constexpr (sizeof(size_t) >= sizeof(uint64_t)) {
+    (void)v;
+    return false;
+  } else {
+    return v > static_cast<uint64_t>(SIZE_MAX);
+  }
+}
+
+// The most a zstd frame can expand, per compressed byte. A zstd block covers at
+// most 128 KiB, and the cheapest way to spell one is an RLE block: a 3-byte
+// block header plus a single byte of content. So no frame can yield more than
+// 131072 / 4 = 32768 bytes per byte it occupies, and a real frame is well under
+// that -- a large array of one repeated value, the most compressible input
+// there is, measures around 12000:1 at every compression level this writer
+// uses. Every frame lives inside the container, so the container's own length
+// is an upper bound on any frame's compressed size, and this ratio times that
+// length is a size no honest frame can declare.
+constexpr uint64_t kMaxExpansionRatio = 32768;
 
 uint64_t LoadU64(const uint8_t *p) {
   uint64_t v = 0;
@@ -132,6 +158,14 @@ class ContainerBytes {
       return PVZSTD_E_IO;
     }
     size_ = static_cast<uint64_t>(li.QuadPart);
+    // A container larger than the address space cannot be mapped whole, and
+    // mapping the low bits of its length would leave every offset in the parse
+    // pointing outside the view. Refuse it instead. Unreachable where size_t is
+    // 64 bits.
+    if (ExceedsSizeT(size_)) {
+      Reset();
+      return PVZSTD_E_IO;
+    }
     mapping_ = CreateFileMappingA(handle_, nullptr, PAGE_READONLY, 0, 0, nullptr);
     if (mapping_ == nullptr) {
       Reset();
@@ -151,6 +185,13 @@ class ContainerBytes {
       return PVZSTD_E_IO;
     }
     size_ = static_cast<uint64_t>(st.st_size);
+    // See the Windows arm: a file too large to address cannot be mapped whole,
+    // and truncating its length into mmap would give a view every later offset
+    // reads past the end of.
+    if (ExceedsSizeT(size_)) {
+      Reset();
+      return PVZSTD_E_IO;
+    }
     void *addr = ::mmap(nullptr, static_cast<size_t>(size_), PROT_READ, MAP_PRIVATE, fd_, 0);
     if (addr == MAP_FAILED) {
       Reset();
@@ -168,6 +209,9 @@ class ContainerBytes {
   pvzstd_status Borrow(const void *data, uint64_t size) {
     Reset();
     if (data == nullptr || size == 0) return PVZSTD_E_INVALID;
+    // A borrowed range longer than the address space is a caller error, not a
+    // buffer: nothing could have allocated it.
+    if (ExceedsSizeT(size)) return PVZSTD_E_INVALID;
     data_ = static_cast<const uint8_t *>(data);
     size_ = size;
     owned_ = false;
@@ -266,9 +310,17 @@ size_t DecompressInto(void *dst, size_t dst_capacity, const void *src, size_t sr
 
 pvzstd_status DecompressFrame(const uint8_t *src, uint64_t src_size, uint64_t expected,
                               std::vector<uint8_t> *out) {
+  // Narrowing a 64-bit declared size into resize() would ask for the low bits
+  // of it on a 32-bit target. ParseContainer already refuses every frame size
+  // the container cannot justify; this is the same refusal stated where the
+  // allocation is made, so no future caller can reach the resize without it.
+  if (ExceedsSizeT(expected)) return PVZSTD_E_FORMAT;
   try {
     out->resize(static_cast<size_t>(expected));
-  } catch (const std::bad_alloc &) {
+  } catch (const std::exception &) {
+    // Wider than std::bad_alloc on purpose: an oversized resize() throws
+    // std::length_error, which is not a bad_alloc, so the narrower handler let
+    // it out of the library and left the entry point's catch(...) to answer.
     return PVZSTD_E_NOMEM;
   }
   if (expected == 0) return PVZSTD_OK;
@@ -280,39 +332,54 @@ pvzstd_status DecompressFrame(const uint8_t *src, uint64_t src_size, uint64_t ex
   return PVZSTD_OK;
 }
 
+// Every length here is a 32-bit field read out of the file while `off` is a
+// size_t, which is 32 bits on a WebAssembly target. So each bounds check is
+// written against the bytes that remain -- subtracting from the frame's length
+// rather than adding to an offset, and dividing rather than multiplying -- and
+// the subtractions are ordered so a short frame cannot underflow one. Written
+// the other way round, `off + ndim * 8 + PVZSTD_DTYPE_LEN` wraps for an ndim
+// near 2^29 and turns the guard into a pass, after which the loop below reads
+// eight bytes per dimension past the end of the container.
 pvzstd_status ParseHeader(const std::vector<uint8_t> &buf, ArrayEntry *entry) {
-  size_t off = 0;
-  if (buf.size() < 4) return PVZSTD_E_FORMAT;
+  const uint64_t size = buf.size();
+  uint64_t off = 0;
+  if (size < 4) return PVZSTD_E_FORMAT;
   const uint32_t name_len = LoadU32(buf.data());
-  off += 4;
-  if (buf.size() < off + name_len + 4) return PVZSTD_E_FORMAT;
-  entry->name.assign(reinterpret_cast<const char *>(buf.data() + off), name_len);
+  off = 4;
+  // size >= 4 == off, so the subtraction stands; the sum is in uint64, where a
+  // uint32 name length plus four cannot wrap.
+  if (size - off < static_cast<uint64_t>(name_len) + 4) return PVZSTD_E_FORMAT;
+  entry->name.assign(reinterpret_cast<const char *>(buf.data() + static_cast<size_t>(off)),
+                     name_len);
   off += name_len;
 
-  const uint32_t ndim = LoadU32(buf.data() + off);
+  const uint32_t ndim = LoadU32(buf.data() + static_cast<size_t>(off));
   off += 4;
-  if (buf.size() < off + static_cast<size_t>(ndim) * 8 + PVZSTD_DTYPE_LEN) return PVZSTD_E_FORMAT;
+  // off <= size holds from the check above, and the dtype field is subtracted
+  // before the divide so neither step can underflow.
+  if (size - off < PVZSTD_DTYPE_LEN) return PVZSTD_E_FORMAT;
+  if ((size - off - PVZSTD_DTYPE_LEN) / 8 < ndim) return PVZSTD_E_FORMAT;
   entry->shape.clear();
   for (uint32_t i = 0; i < ndim; ++i) {
-    entry->shape.push_back(LoadU64(buf.data() + off));
+    entry->shape.push_back(LoadU64(buf.data() + static_cast<size_t>(off)));
     off += 8;
   }
 
   // dtype is space-padded to 16 bytes; strip trailing blanks.
   size_t dtype_len = PVZSTD_DTYPE_LEN;
-  while (dtype_len > 0 && buf[off + dtype_len - 1] == ' ') --dtype_len;
-  std::memcpy(entry->dtype, buf.data() + off, dtype_len);
+  while (dtype_len > 0 && buf[static_cast<size_t>(off) + dtype_len - 1] == ' ') --dtype_len;
+  std::memcpy(entry->dtype, buf.data() + static_cast<size_t>(off), dtype_len);
   entry->dtype[dtype_len] = '\0';
   off += PVZSTD_DTYPE_LEN;
 
   // Absent filter byte means PVZSTD_FILTER_NONE. Testing file_version instead
   // would mis-parse a shuffled version-2 file.
   entry->filter_id = PVZSTD_FILTER_NONE;
-  if (off < buf.size()) {
-    entry->filter_id = buf[off];
+  if (off < size) {
+    entry->filter_id = buf[static_cast<size_t>(off)];
     off += 1;
   }
-  if (off != buf.size()) return PVZSTD_E_FORMAT;
+  if (off != size) return PVZSTD_E_FORMAT;
   return PVZSTD_OK;
 }
 
@@ -347,6 +414,19 @@ pvzstd_status ParseContainer(pvzstd_reader *reader, uint32_t *file_version) {
     const uint8_t *p = raw.data() + index_off + i * kIndexEntryBytes;
     ends[static_cast<size_t>(i)] = LoadU64(p);  // END offset, not start
     sizes[static_cast<size_t>(i)] = LoadU64(p + 8);
+    // Refuse an impossible decompressed size here, before anything asks the
+    // allocator for it. The index is file-supplied and unrelated to what the
+    // frame actually holds, so a crafted one can name any 64-bit number; a
+    // frame can only occupy bytes the container has, and kMaxExpansionRatio is
+    // the most zstd can turn each of those into. Divided rather than multiplied
+    // so the comparison itself cannot wrap. Relying on the resize to throw
+    // instead is not enough: the throw is what a build with exceptions turned
+    // off cannot answer, and on a 32-bit target the size would be truncated
+    // before it ever reached the allocator.
+    const uint64_t declared = sizes[static_cast<size_t>(i)];
+    if (declared / kMaxExpansionRatio > raw.size() || ExceedsSizeT(declared)) {
+      return PVZSTD_E_FORMAT;
+    }
   }
 
   // Banked before the frame walk: the walk consumes the metadata frames and
@@ -667,6 +747,10 @@ pvzstd_status pvzstd_read_arrays(const pvzstd_reader *reader, const uint64_t *in
     return PVZSTD_E_INVALID;
   }
   if (count == 0) return PVZSTD_OK;
+  // The parallel path indexes a vector of `count` results with a uint64 loop
+  // counter. Narrowing the count into that vector's size on a 32-bit target
+  // would size it from the low bits and then write past the end of it.
+  if (ExceedsSizeT(count)) return PVZSTD_E_RANGE;
 
   int workers = n_threads;
   if (workers == PVZSTD_THREADS_AUTO) {

--- a/tests/conformance/test_crafted_containers.py
+++ b/tests/conformance/test_crafted_containers.py
@@ -1,0 +1,207 @@
+"""
+Bounds the reader keeps against a container written to break it.
+
+Two of the checks here are 32-bit properties. ``size_t`` is 64 bits on every
+machine this suite normally runs on, so arithmetic that wraps on a 32-bit
+target -- a WebAssembly build is one -- cannot be caught by running the test
+there. The crafted files are therefore written to be refused for a reason that
+holds on every target: the value they declare is impossible against the bytes
+that follow it, so a check written to be wrap-proof refuses it everywhere, and
+a check written the wrapping way passes it exactly where the wrap happens.
+
+Every case is asserted through both doors -- ``pvzstd_open`` on a path and
+``pvzstd_open_memory`` on a buffer -- because they meet at one parse and a
+guard that only one of them reaches is not a guard.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import struct
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+import pyvista as pv
+import zstandard as zstd
+
+import pyvista_zstd as pz
+from pyvista_zstd import _capi
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+INDEX_ENTRY_SIZE = 16
+"""Bytes per trailer index entry: two little-endian u64 fields."""
+
+POISON_NDIM = 2**29
+"""
+A dimension count whose shape table cannot fit in any container.
+
+Chosen so that ``ndim * 8`` is exactly 2**32: on a 32-bit target that product
+wraps to zero, so ``off + ndim * 8 + PVZSTD_DTYPE_LEN`` measures the same
+handful of bytes a well-formed header needs and waves the file through. The
+loop that follows then reads eight bytes per dimension past the end of the
+container. Written as a divide against the bytes remaining, no value of ndim
+can wrap it, and half a billion dimensions is refused for the reason it should
+be: the frame does not hold them.
+"""
+
+POISON_DECOMPRESSED_SIZE = 2**60 + 2**31
+"""
+A declared frame size no container could produce.
+
+Both halves matter. 2**60 is absurd on any target: the index says this frame
+decompresses to an exabyte, which no allocator will serve, so a reader that
+relies on the allocation failing is relying on a throw. Its low 32 bits are
+2**31, so a 32-bit build that narrows the declared size into ``resize`` still
+asks for 2 GiB rather than truncating to something small and harmless -- which
+is what turned this into an abort on WebAssembly instead of a status.
+"""
+
+
+def _dataset() -> pv.DataSet:
+    rng = np.random.default_rng(5)
+    ds = pv.Sphere(theta_resolution=10, phi_resolution=10)
+    ds.point_data["scal_f64"] = rng.random(ds.n_points)
+    return ds
+
+
+@pytest.fixture
+def container(tmp_path: Path) -> bytes:
+    """Write a small single-dataset container and return its bytes."""
+    path = tmp_path / "crafted_source.pv"
+    pz.write(_dataset(), path, progress_bar=False)
+    return path.read_bytes()
+
+
+def _split(raw: bytes) -> list[list]:
+    """Return ``[compressed_bytes, declared_size]`` per frame, in file order."""
+    (n_frames,) = struct.unpack("<Q", raw[-8:])
+    index_off = len(raw) - 8 - n_frames * INDEX_ENTRY_SIZE
+    frames: list[list] = []
+    start = 0
+    for i in range(n_frames):
+        end, size = struct.unpack_from("<QQ", raw, index_off + i * INDEX_ENTRY_SIZE)
+        frames.append([raw[start:end], size])
+        start = end
+    return frames
+
+
+def _rebuild(frames: list[list]) -> bytes:
+    """Concatenate the frames and re-emit the trailer index over them."""
+    out = bytearray(b"".join(comp for comp, _ in frames))
+    end = 0
+    for comp, size in frames:
+        end += len(comp)
+        out += struct.pack("<QQ", end, size)
+    out += struct.pack("<Q", len(frames))
+    return bytes(out)
+
+
+def _patch_first_header(raw: bytes, mutate) -> bytes:
+    """Rewrite frame 0 -- always an array header -- through *mutate*."""
+    frames = _split(raw)
+    plain = zstd.ZstdDecompressor().decompress(frames[0][0], max_output_size=1 << 20)
+    patched = mutate(bytearray(plain))
+    frames[0][0] = zstd.ZstdCompressor(level=3).compress(bytes(patched))
+    frames[0][1] = len(patched)
+    return _rebuild(frames)
+
+
+def _status_from_path(raw: bytes, tmp_path: Path) -> int:
+    """Open *raw* as a file and return the status, closing on success."""
+    lib = _capi._load()  # noqa: SLF001
+    path = tmp_path / "crafted.pv"
+    path.write_bytes(raw)
+    handle = ctypes.c_void_p()
+    status = lib.pvzstd_open(str(path).encode("utf-8"), ctypes.byref(handle))
+    if status == _capi._STATUS_OK:  # noqa: SLF001
+        lib.pvzstd_close(handle)
+    return int(status)
+
+
+def _status_from_memory(raw: bytes) -> int:
+    """Open *raw* as a buffer and return the status, closing on success."""
+    lib = _capi._load()  # noqa: SLF001
+    buffer = np.frombuffer(raw, dtype=np.uint8)
+    handle = ctypes.c_void_p()
+    status = lib.pvzstd_open_memory(
+        ctypes.c_void_p(buffer.ctypes.data),
+        ctypes.c_uint64(buffer.nbytes),
+        ctypes.byref(handle),
+    )
+    if status == _capi._STATUS_OK:  # noqa: SLF001
+        lib.pvzstd_close(handle)
+    return int(status)
+
+
+def _both_doors(raw: bytes, tmp_path: Path) -> tuple[int, int]:
+    return _status_from_path(raw, tmp_path), _status_from_memory(raw)
+
+
+def test_the_control_container_opens_through_both_doors(container: bytes, tmp_path: Path) -> None:
+    """Rebuilt but unmodified, the container must still parse, or nothing below means anything."""
+    rebuilt = _rebuild(_split(container))
+    assert _both_doors(rebuilt, tmp_path) == (_capi._STATUS_OK, _capi._STATUS_OK)  # noqa: SLF001
+
+
+def test_an_absurd_ndim_is_refused_rather_than_multiplied(container: bytes, tmp_path: Path) -> None:
+    """A shape table the frame cannot hold is a format error, not an out-of-bounds read."""
+
+    def poison(header: bytearray) -> bytearray:
+        (name_len,) = struct.unpack_from("<I", header, 0)
+        struct.pack_into("<I", header, 4 + name_len, POISON_NDIM)
+        return header
+
+    raw = _patch_first_header(container, poison)
+    expected = (_capi._STATUS_FORMAT, _capi._STATUS_FORMAT)  # noqa: SLF001
+    assert _both_doors(raw, tmp_path) == expected, (
+        f"a header declaring {POISON_NDIM} dimensions in a frame of a few dozen bytes was accepted"
+    )
+
+
+def test_an_absurd_declared_size_is_refused_before_the_allocation(container: bytes, tmp_path: Path) -> None:
+    """
+    A frame size the container could not have produced comes back as a status.
+
+    The point is that it is a status at all. Leaving this to the allocator
+    means leaving it to a throw, and a build with exception catching turned off
+    -- Emscripten's default -- turns that throw into ``abort()`` rather than
+    into ``PVZSTD_E_NOMEM``.
+    """
+    frames = _split(container)
+    frames[0][1] = POISON_DECOMPRESSED_SIZE
+    raw = _rebuild(frames)
+
+    expected = (_capi._STATUS_FORMAT, _capi._STATUS_FORMAT)  # noqa: SLF001
+    assert _both_doors(raw, tmp_path) == expected, (
+        "an index declaring a frame far larger than the container it lives in was not refused"
+    )
+
+
+def test_a_highly_compressible_array_still_reads(tmp_path: Path) -> None:
+    """
+    The ceiling on a declared frame size must not refuse a real file.
+
+    A large array of one repeated value is the most compressible input the
+    format will ever be handed: it compresses at roughly 10000:1, so its
+    payload frame declares a decompressed size thousands of times the length of
+    the frame that holds it. That is the case a ratio-based bound gets wrong if
+    it is drawn too tight, so it is written deliberately rather than waited for.
+    """
+    ds = pv.ImageData(dimensions=(128, 128, 128))
+    ds.point_data["constant_f64"] = np.full(ds.n_points, 3.25, dtype=np.float64)
+    path = tmp_path / "compressible.pv"
+    pz.write(ds, path, progress_bar=False)
+
+    raw = path.read_bytes()
+    declared = max(size for _, size in _split(raw))
+    assert declared > 8 * len(raw), (
+        f"the container is {len(raw)} bytes and its largest frame declares {declared}; "
+        "this input did not compress enough to test the bound"
+    )
+
+    back = pz.read(path)
+    assert np.array_equal(back.point_data["constant_f64"], ds.point_data["constant_f64"])
+    assert _status_from_memory(raw) == _capi._STATUS_OK  # noqa: SLF001


### PR DESCRIPTION
Two defects that only bite on the WebAssembly build. Both were reproduced under Emscripten against crafted containers, and the native build answers correctly on the same bytes, which is why neither showed up before.

Resolves #47, resolves #48.

## The 32-bit narrowing

`ParseHeader` computed its bounds check as `off + ndim * 8 + PVZSTD_DTYPE_LEN` in `size_t`. On wasm32 that is 32 bits, so a crafted `ndim` wrapped it and passed a check meant to refuse it, after which the shape loop read eight bytes per dimension past the end of the buffer. Every bounds check there is now done in `uint64_t` against the bytes remaining, subtract-then-divide, ordered so a short frame cannot underflow.

The audit that followed found the same overflow one line earlier, in `buf.size() < off + name_len + 4`, which wraps for a `name_len` near 2^32. It also added an explicit refusal at four places where a 64-bit container field or caller argument narrows to `size_t`: the `mmap` / `MapViewOfFile` length, where a file over 4 GiB would map a truncated view and every later offset would read past it; the borrowed buffer size; the decompression `resize`; and the `results` vector in `pvzstd_read_arrays`.

Audited and left alone, with reasons: the `ends` and `sizes` sizing is already bounded by the divide-first frame-count guard, the pointer arithmetic in `ParseContainer` is bounded by the container length, `DeclaredSizeAgrees` is pure `uint64_t`, and the `static_cast<size_t>(dst_size)` in `pvzstd_read_array_at` can only understate a capacity, so it errors rather than overruns.

## The exception net that was not there

Emscripten defaults to `-sDISABLE_EXCEPTION_CATCHING=1`, so every `catch (...)` at the `extern "C"` boundary was compiled away and a throw called `abort()`. The header promises a status code and on that target it did not deliver one.

`-fwasm-exceptions` is now set on the target behind `if(EMSCRIPTEN)`, at compile and at link, in preference to `-sNO_DISABLE_EXCEPTION_CATCHING`, which is the legacy JavaScript unwinder and taxes every call site whether or not anything throws. It is `PUBLIC` rather than `PRIVATE` because a wasm link cannot mix exception models: a consumer compiling its own translation units against this library has to be on the same one. It is scoped to the target rather than set globally, so an embedding project keeps its own flags everywhere else.

The flag is the safety net, not the fix. Every index-declared decompressed size is now refused at parse time when `declared / 32768 > container_bytes`. 32768 is zstd's own format ceiling rather than a guess: a 128 KiB block spelled as an RLE block costs a three-byte block header plus one content byte, and a frame's compressed bytes are never more than the container's. It was measured against real data rather than assumed. 64 MiB of one repeated float compresses about 10,900:1 at every level, and the deliberately incompressible-resistant test container is 2,303 bytes declaring a 16 MiB frame, a ratio of 7,285:1, inside the bound with 4.5x headroom.

The narrow `catch (const std::bad_alloc &)` at the decompression path is widened to `std::exception`, since an oversized `resize` throws `std::length_error`, which the narrower handler never caught on any target.

## Evidence

Under Emscripten on the threads-off lane, through `pvzstd_dump.js`:

| crafted container | before | after |
| --- | --- | --- |
| `ndim` of 2^29 | `Aborted()` | `PVZSTD_E_FORMAT` |
| index size 2^60 + 2^31 | unhandled rejection | `PVZSTD_E_FORMAT` |
| 3 GiB frame inside the ratio bound | unhandled rejection | `PVZSTD_E_NOMEM` |

The third row is the isolated proof that the flag itself works. That container passes the new ceiling, so it still throws, and only the exception model turns the throw into a status. Same results on the threads lane. Suite is 225 passing, up from 221.

## Left for a follow-up

Eleven other `catch (const std::bad_alloc &)` sites in `writer.cpp`, `stream.cpp` and `append.cpp` have the same `length_error` gap. The exception flag now covers them on wasm, but none has a narrowing guard in front of it.
