### PR TITLE
Limit the GITHUB_TOKEN to what each workflow actually needs

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -13,6 +13,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege by default. The release job raises its own, and is the only
+# job here that needs more than a checkout.
+permissions:
+  contents: read
+
 env:
   ALLOW_PLOTTING: true
   SHELLOPTS: "errexit:pipefail"

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -13,6 +13,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege: every job here only reads the repository.
+permissions:
+  contents: read
+
 env:
   SHELLOPTS: "errexit:pipefail"
 

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -3,9 +3,17 @@ on:
   pull_request_target:
     types: [opened, reopened]
 
+# pull_request_target runs with the base repository's token, so the grant here
+# is the whole blast radius of a labeler acting on a fork's pull request.
+permissions:
+  contents: read
+
 jobs:
   triage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # actions/labeler reads .github/labeler.yml
+      pull-requests: write # the labels are the point
     steps:
       - name: Label based on changed files
         uses: actions/labeler@v7


### PR DESCRIPTION
CodeQL flagged the moved `wheels` and `sdist` jobs in https://github.com/pyvista/pyvista-zstd/pull/51 for running with an unrestricted `GITHUB_TOKEN`. It was right, and it was already true of five other jobs before that PR: alerts exist for `ci_cd.yml` at two more jobs, `cpp.yml` at four, and `label.yml`. Moving the jobs made an existing gap visible rather than creating one.

Every workflow now declares `permissions: contents: read` at the top, which is all any job here needs to check out and build.

The two exceptions keep their own block, one job each. `release` already declared `id-token: write` for trusted publishing and `contents: write` for creating the GitHub release, and that is unchanged. `label.yml`'s `triage` job gets `pull-requests: write`, because applying labels is the entire job, alongside `contents: read` for `actions/labeler` to read its config.

`label.yml` is the one worth a second look: it triggers on `pull_request_target`, so it runs with the base repository's token against a fork's pull request. The grant there is the whole blast radius, and until now it was the default one.
