### PR TITLE
Run pre-commit on every pull request

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -18,6 +18,19 @@ env:
   SHELLOPTS: "errexit:pipefail"
 
 jobs:
+  pre-commit:
+    name: pre-commit
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+
+      - uses: pre-commit/action@v3.0.1
+
   doc:
     name: Build Documentation
     runs-on: ubuntu-24.04

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,3 @@
-ci:
-  # clang-format's fixes are mechanical; let the service push them.
-  autofix_prs: true
-  autofix_commit_msg: "style: pre-commit.ci auto fixes"
-  autoupdate_schedule: quarterly
-
 repos:
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v21.1.2

--- a/tests/conformance/test_c_abi_runtime.py
+++ b/tests/conformance/test_c_abi_runtime.py
@@ -106,7 +106,8 @@ def test_a_library_without_the_symbols_is_a_load_failure() -> None:
 
 
 def test_read_array_at_accepts_a_null_destination_for_a_zero_byte_array(tmp_path: Path) -> None:
-    """A zero-byte read must succeed even with a null destination.
+    """
+    A zero-byte read must succeed even with a null destination.
 
     ``pv.Sphere()`` has no lines, verts, or strips, so its
     ``lines_connectivity``, ``verts_connectivity`` and ``strips_connectivity``


### PR DESCRIPTION
The hooks in `.pre-commit-config.yaml` ran only for people who installed them locally, so a pull request could land violating any of them.

Resolves #40.

That included `forbid-pvz`, which is the only thing keeping the retired `pvz_` prefix from creeping back into the C ABI after it moved to `pvzstd_`. It is now checked on every pull request, and the hook was verified to fire by planting a `pvz_bogus_symbol` and watching it reject the file.

A new `pre-commit` job in `ci_cd.yml` rather than a place in an existing one. `doc` builds docs, `unit_testing`, `wheels` and `sdist` are OS and version matrices where a lint pass would run redundantly on every leg, and `cpp.yml`'s jobs are C++ matrix work. `pre-commit/action` caches its own environments keyed on the config file.

The `ci:` block at the top of `.pre-commit-config.yaml` is deleted. It configured pre-commit.ci, which is not installed on this repository, so it described coverage that did not exist. A reader finding it would reasonably conclude the gap was already handled, which is how this went unnoticed.

One existing violation had to be fixed for the new job to be green on arrival: a docstring in `tests/conformance/test_c_abi_runtime.py` put its summary on the first line. `pyproject.toml` selects `ALL` and explicitly ignores D212, so D213 is the house style here and every other multi-line docstring in that file already followed it. It is a separate commit from the workflow change.

A gate that fails the moment it lands teaches people to ignore it, so `pre-commit run --all-files` was run against the committed tree: all 14 hooks pass.

The three shellcheck SC2102 hints `actionlint` reports in `ci_cd.yml` and `cpp.yml` are pre-existing, present before this branch, and left alone.
