### PR TITLE
Document the C ABI and the pvzstd CMake package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,6 +132,25 @@ No additional imports needed. This works via PyVista's ``pyvista.readers``
 entry point group, so the registration happens at install time.
 
 
+The C library
+~~~~~~~~~~~~~
+
+The reader and writer are a C++ core with a pure C ABI, ``pvzstd``, declared in
+``cpp/include/pvzstd/pvzstd.h``. The Python package is one consumer of it,
+bound with ``ctypes``; a C or C++ consumer -- or a WebAssembly build -- can link
+the same library directly, and it depends on nothing but zstd.
+
+.. code:: cmake
+
+   find_package(pvzstd CONFIG REQUIRED)
+   target_link_libraries(my_app PRIVATE pvzstd::pvzstd)
+
+See `The C library <https://pyvista.github.io/pyvista-zstd/c_api.html>`__ for
+the build options, both ways of consuming the CMake package, the ABI-version
+contract, and a worked example. The on-disk format is specified in
+``doc/format/container-v2.md``.
+
+
 Rational
 ~~~~~~~~
 

--- a/doc/c_api.rst
+++ b/doc/c_api.rst
@@ -1,0 +1,530 @@
+The C library
+=============
+
+The reader and writer live in a C++ core, ``pvzstd``, and the whole of its
+public surface is a C ABI declared in a single header,
+``cpp/include/pvzstd/pvzstd.h``. The Python package is one consumer of that
+ABI, bound with :mod:`ctypes`; nothing in the ABI is Python-specific, and a C
+or C++ consumer can link the same library directly.
+
+Two properties are what make that worth doing:
+
+* **The interface is pure C.** No C++ type, no zstd type, and no VTK type
+  appears in the header, so it binds from C, from C++, from ``ctypes``, or from
+  any FFI that can call a C function. Turning a dataset into arrays stays with
+  the caller, which is what keeps VTK out of the library and lets it build as
+  WebAssembly.
+* **The only dependency is zstd**, and it is linked privately. The header never
+  names a zstd type, so for the default shared build zstd is an implementation
+  detail of ``libpvzstd`` rather than something a consumer has to find. (See
+  :ref:`c_api_static_caveat` for the one case where that does not hold.)
+
+The on-disk format the library reads and writes is specified in
+``doc/format/container-v2.md``.
+
+
+Building
+--------
+
+The core is an ordinary CMake project rooted at ``cpp/``:
+
+.. code:: bash
+
+   cmake -S cpp -B build -DCMAKE_BUILD_TYPE=Release
+   cmake --build build -j
+   cmake --install build --prefix /where/you/want/it
+
+The install tree carries the library, the header under ``include/pvzstd/``, and
+a CMake package under ``lib/cmake/pvzstd/``.
+
+Options
+~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 26 12 62
+
+   * - Option
+     - Default
+     - Meaning
+   * - ``PVZSTD_BUILD_SHARED``
+     - ``ON``
+     - Build a shared library. The Python ``ctypes`` binding needs one. A
+       static build is possible but exports zstd resolution to the consumer;
+       see :ref:`c_api_static_caveat`.
+   * - ``PVZSTD_BUILD_TOOLS``
+     - ``ON``
+     - Build the command-line tools ``pvzstd_dump``, ``pvzstd_rewrite``,
+       ``pvzstd_append`` and ``pvzstd_stream``. They are conformance and
+       inspection aids, not part of the ABI; turn them off for a build that
+       only ships the library.
+   * - ``PVZSTD_THREADS``
+     - ``ON``
+     - Use threads for batch decompression and for zstd's own workers. Turn it
+       off for a target with no thread runtime. Reads are unaffected. Writes
+       lose byte-identity with the reference writer above its 2 MiB threshold,
+       and say so: a zstd built without multithreading rejects a non-zero
+       worker count, so ``pvzstd_writer_write`` returns ``PVZSTD_E_ZSTD``
+       rather than quietly emitting frames that would not match.
+   * - ``PVZSTD_ZSTD_PROVIDER``
+     - ``auto``
+     - Where zstd comes from. ``auto`` prefers an installed zstd and falls back
+       to the pinned source build; ``system`` requires an installed one and
+       fails configuration if there is none; ``vendored`` always builds the
+       pinned source, ignoring anything installed.
+   * - ``PVZSTD_VENDOR_ZSTD``
+     - ``ON``
+     - Whether the pinned source build is available as a fallback at all. With
+       it ``OFF`` and no zstd installed, configuration fails rather than
+       downloading anything.
+
+``vendored`` is not paranoia about versions in general: different zstd releases
+emit different, equally valid frames for the same input, so the conformance
+suite has to pin the same source the reference writer carries. Linking a system
+zstd instead was measured to fail the byte-identity tests on multi-frame data
+that platforms without a system zstd passed. A distribution build that cares
+more about receiving zstd's security updates than about byte-identity should
+prefer ``system``.
+
+The pinned source build is also what makes Windows and WebAssembly possible at
+all, since neither has a system zstd to find.
+
+
+Consuming it
+------------
+
+Both paths yield the same target name, ``pvzstd::pvzstd``, so the rest of a
+consumer's CMake does not have to know which one was taken.
+
+Against an install tree
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: cmake
+
+   find_package(pvzstd CONFIG REQUIRED)
+   target_link_libraries(my_app PRIVATE pvzstd::pvzstd)
+
+Point ``CMAKE_PREFIX_PATH`` at the install prefix if it is not already on the
+search path. The package's version is the released version line
+(``find_package(pvzstd 0.3)`` means what a reader expects), and it is compatible
+within a major version. It is *not* the compatibility contract a consumer should
+rely on at runtime: that is ``PVZSTD_ABI_VERSION``, below.
+
+Against the source
+~~~~~~~~~~~~~~~~~~
+
+As a subdirectory -- a submodule, a vendored copy, or a sibling checkout:
+
+.. code:: cmake
+
+   add_subdirectory(third_party/pyvista-zstd/cpp pvzstd)
+   target_link_libraries(my_app PRIVATE pvzstd::pvzstd)
+
+or fetched at configure time:
+
+.. code:: cmake
+
+   include(FetchContent)
+   FetchContent_Declare(pvzstd
+     GIT_REPOSITORY https://github.com/pyvista/pyvista-zstd.git
+     GIT_TAG        main
+     SOURCE_SUBDIR  cpp)
+   FetchContent_MakeAvailable(pvzstd)
+   target_link_libraries(my_app PRIVATE pvzstd::pvzstd)
+
+``pvzstd::pvzstd`` is an ``ALIAS`` of the in-tree target in these two cases and
+an imported target in the ``find_package`` case, which is the point of having
+the alias: one link line serves all three.
+
+.. _c_api_static_caveat:
+
+The static build does not carry zstd
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+zstd is linked ``PRIVATE``. For the default shared build that folds zstd's
+object code into ``libpvzstd`` itself, so the installed library is
+self-contained whether zstd was vendored or found on the system.
+
+It does **not** hold for ``-DPVZSTD_BUILD_SHARED=OFF``. CMake does not fold a
+private static dependency's objects into the resulting archive, so
+``libpvzstd.a`` still needs zstd's symbols resolved at the consumer's link step,
+and the exported package does not declare that dependency -- zstd is treated as
+this build's implementation detail, not a re-exported one. With a system zstd a
+consumer can supply it themselves. With ``PVZSTD_ZSTD_PROVIDER=vendored`` the
+vendored zstd happens to install its own findable package alongside this one, as
+a side effect of ``FetchContent`` adding it as a subdirectory rather than
+anything this project arranges, so it is not strictly unfindable -- but that is
+fragile and not worth designing around. Prefer the shared build for anything
+that will be installed and linked downstream.
+
+
+The ABI version
+---------------
+
+.. code:: c
+
+   #define PVZSTD_ABI_VERSION 10u
+   PVZSTD_API uint32_t pvzstd_abi_version(void);
+
+The macro is the version the caller compiled against; the function is the
+version the library it actually loaded was built with. **Compare them for
+equality, not as a floor.** The number is bumped on any change to the header,
+additions included, because a caller that binds every symbol up front -- which
+is what an FFI binding does -- is broken by an addition just as surely as by a
+removal, if it looks for a symbol the loaded library does not have.
+
+.. code:: c
+
+   if (pvzstd_abi_version() != PVZSTD_ABI_VERSION) {
+     /* wrong library; do not call anything else */
+   }
+
+Calling the function is also the cheapest real proof that a library linked and
+loaded at all. A header parses whether or not anything is behind it, and CMake
+reporting a successful link says only that the symbols resolved at build time,
+not that the shared object the loader picks up at runtime is the right one -- or
+that it is present. ``pvzstd_abi_version()`` is a call into that object with no
+arguments and no failure mode, so a correct answer from it means the library is
+there, is loadable, and is the one the header describes. The Python binding does
+exactly this at import time, so that a bad install fails at import naming what
+it tried rather than at the first read.
+
+A second, separate number describes the *files* rather than the library:
+
+.. code:: c
+
+   #define PVZSTD_FILE_VERSION_MAX 2u
+   PVZSTD_API uint32_t pvzstd_max_file_version(void);
+
+This is the highest container ``file_version`` the build can decode. A container
+stamped higher is refused with ``PVZSTD_E_VERSION`` rather than read, because a
+newer format may transform payloads in a way this build cannot invert, and
+reading one would hand back plausible-looking corrupt values instead of failing.
+The ceiling lives beside the decoder it describes so that every caller of the
+ABI gets the same answer; a binding keeping its own copy would refuse files the
+library can read, or accept files it cannot.
+
+
+Reading a container
+-------------------
+
+A reader is opened, queried, read from, and closed. Opening parses only the
+trailer and the array headers; payloads are decompressed on demand, one array at
+a time.
+
+.. code:: c
+
+   pvzstd_status pvzstd_open(const char *path, pvzstd_reader **out);
+   pvzstd_status pvzstd_open_versioned(const char *path, pvzstd_reader **out,
+                                       uint32_t *file_version);
+   pvzstd_status pvzstd_open_memory(const void *data, uint64_t size,
+                                    pvzstd_reader **out);
+   pvzstd_status pvzstd_open_memory_versioned(const void *data, uint64_t size,
+                                              pvzstd_reader **out,
+                                              uint32_t *file_version);
+   void pvzstd_close(pvzstd_reader *reader);
+
+On success ``*out`` receives a reader that must be released with
+``pvzstd_close``. On failure ``*out`` is set to ``NULL``. ``pvzstd_close``
+accepts ``NULL``.
+
+The ``_versioned`` variants additionally report the container's own
+``file_version``, **including when the open was refused for being too new**,
+which is precisely the case in which a caller needs the number -- to say what it
+found against ``pvzstd_max_file_version()``. The out-parameter may be ``NULL``,
+and is left untouched when the container carried no readable version.
+
+Opening from memory
+~~~~~~~~~~~~~~~~~~~
+
+``pvzstd_open_memory`` takes ``size`` contiguous bytes of a whole container that
+the caller already holds: an archive member, an HTTP response body, or a build
+with no filesystem to open a path on. It refuses a crafted buffer wherever
+``pvzstd_open`` would refuse a crafted file.
+
+**The bytes are borrowed, never copied.** The caller owns the buffer and must
+keep it allocated and unmodified until ``pvzstd_close``, which is what makes
+this cheaper than staging the container somewhere the path entry point can
+reach. ``pvzstd_close`` releases only what the reader itself acquired; the
+buffer is left alone and is the caller's to free afterwards.
+
+Modifying the buffer while a reader is open **is not detected**. Offsets and
+sizes were read at open time, so arrays read afterwards hold undefined contents
+and no status reports it.
+
+One difference between the two doors is deliberate. A ``NULL`` pointer, or a
+``size`` of zero, is ``PVZSTD_E_INVALID``: a zero size is a bad argument. A
+zero-length *file* is a property of the thing being opened and so reaches
+``pvzstd_open`` as ``PVZSTD_E_IO``. A caller writing one error handler over both
+entry points should expect that.
+
+Describing arrays
+~~~~~~~~~~~~~~~~~
+
+.. code:: c
+
+   typedef struct pvzstd_array_info {
+     const char *name;      /* NUL-terminated, UTF-8, includes the UID prefix */
+     const uint64_t *shape; /* ndim entries; NULL when ndim == 0 */
+     uint32_t ndim;
+     uint8_t filter_id;
+     char dtype[PVZSTD_DTYPE_LEN + 1]; /* e.g. "<f8", "|u1"; NUL-terminated */
+     uint64_t nbytes;                  /* decompressed payload size */
+   } pvzstd_array_info;
+
+   uint64_t      pvzstd_array_count(const pvzstd_reader *reader);
+   pvzstd_status pvzstd_array_info_at(const pvzstd_reader *reader, uint64_t index,
+                                      pvzstd_array_info *out);
+   pvzstd_status pvzstd_array_info_range(const pvzstd_reader *reader, uint64_t first,
+                                         uint64_t count, pvzstd_array_info *out);
+   int64_t       pvzstd_find_array(const pvzstd_reader *reader, const char *name);
+
+Arrays are addressed by index in frame order, or by name. Frame order is
+significant: it is how the container maps names to frames. ``pvzstd_array_count``
+excludes the two JSON metadata frames. ``pvzstd_find_array`` returns ``-1`` when
+there is no such name; note that stored names carry a 16-character dataset-UID
+prefix, so a caller matching a logical name usually compares suffixes rather than
+whole strings.
+
+The pointers in ``pvzstd_array_info`` **are owned by the reader** and stay valid
+only until ``pvzstd_close``. ``dtype`` is an inline array, so it is copied into
+the caller's struct; ``name`` and ``shape`` are not. A caller that outlives the
+reader must copy them.
+
+``pvzstd_array_info_range`` describes ``count`` arrays in one boundary crossing
+rather than one per array, which matters for a binding where each call is
+expensive. It returns ``PVZSTD_E_RANGE`` and writes nothing if the range runs
+past the end; a count of zero succeeds.
+
+Reading payloads
+~~~~~~~~~~~~~~~~
+
+.. code:: c
+
+   pvzstd_status pvzstd_read_array_at(const pvzstd_reader *reader, uint64_t index,
+                                      void *dst, uint64_t dst_size);
+   pvzstd_status pvzstd_read_arrays(const pvzstd_reader *reader,
+                                    const uint64_t *indices, uint64_t count,
+                                    void *const *dsts, const uint64_t *dst_sizes,
+                                    int n_threads, uint64_t *failed_slot);
+
+The destination is the caller's, always. ``dst_size`` must be at least the
+``nbytes`` the array's info reported, or ``PVZSTD_E_RANGE`` comes back and
+nothing is written. Any per-array filter is reversed on the way out; an unknown
+filter id is ``PVZSTD_E_FILTER``, never a passthrough, because handing back
+filtered bytes as-is would silently corrupt the array.
+
+``pvzstd_read_arrays`` decompresses several arrays over ``n_threads`` workers,
+``indices[i]`` into ``dsts[i]``. Frames are independent, so this is a pure
+fan-out: the work and its order do not depend on the thread setting. ``0`` or
+``1`` runs inline, a negative value means one worker per logical CPU, and
+``PVZSTD_THREADS_AUTO`` picks from the total size. It returns the first non-OK
+status *by slot*, not by whichever worker failed first, so the result is
+deterministic. ``failed_slot`` is optional and receives the index into
+``indices`` that the status is about, or ``PVZSTD_SLOT_NONE``; without it a
+caller learns only that one of the batch was refused and has to re-read them
+singly to find out which.
+
+Metadata and frame sizes
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+``pvzstd_ds_metadata_json`` and ``pvzstd_file_metadata_json`` return the two JSON
+documents, NUL-terminated and owned by the reader, either possibly ``NULL``. For
+a MultiBlock container the dataset-metadata accessor reports an arbitrary
+block's, so a caller rebuilding a hierarchy should use the by-index family --
+``pvzstd_metadata_count``, ``pvzstd_metadata_name_at``,
+``pvzstd_metadata_json_at`` -- which yields every document in file order along
+with the frame name each was stored under.
+
+``pvzstd_field_array_count``, ``pvzstd_field_array_name_at`` and
+``pvzstd_find_field_array`` cover the field arrays an append adds, named without
+the UID prefix or the ``__field_data`` suffix the frame carries.
+
+``pvzstd_frame_count`` and ``pvzstd_frame_sizes`` expose the trailer's own
+numbers -- two frames per array, ``(header, payload)``, in file order, metadata
+frames included -- so a caller can answer "how big is this file decompressed"
+without parsing the trailer itself.
+
+
+Errors
+------
+
+**Every entry point reports failure as a status code**, and no exception is ever
+allowed to cross the boundary: a caller reaching this ABI through ``ctypes`` or
+another FFI has no way to catch one. Accessors that return a pointer or a count
+instead of a status report failure as ``NULL`` or as zero, which are the values
+they already use for "cannot answer". ``pvzstd_status_message`` maps a status to
+a static, human-readable string and is never ``NULL``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Status
+     - Meaning
+   * - ``PVZSTD_OK``
+     - Success.
+   * - ``PVZSTD_E_IO``
+     - File missing, unreadable, or truncated.
+   * - ``PVZSTD_E_FORMAT``
+     - Trailer or header did not parse.
+   * - ``PVZSTD_E_ZSTD``
+     - zstd rejected a frame or a compression parameter.
+   * - ``PVZSTD_E_RANGE``
+     - Index or count out of range, or destination too small.
+   * - ``PVZSTD_E_NOMEM``
+     - Allocation failed.
+   * - ``PVZSTD_E_FILTER``
+     - A per-array filter id this build cannot reverse.
+   * - ``PVZSTD_E_INVALID``
+     - ``NULL`` argument or misuse.
+   * - ``PVZSTD_E_UNSUPPORTED``
+     - The container is a shape this operation cannot serve.
+   * - ``PVZSTD_E_EXISTS``
+     - The name is already taken, and would be overwritten.
+   * - ``PVZSTD_E_VERSION``
+     - The container's ``file_version`` is newer than this build decodes.
+
+The last three are refusals rather than damage: the file parsed, and the
+operation is the thing being declined. A caller that cannot tell them from
+``PVZSTD_E_FORMAT`` has to report a well-formed container as corrupt.
+
+.. _c_api_wasm_exceptions:
+
+WebAssembly must catch exceptions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The promise above is implemented: every ``extern "C"`` entry point is a function
+try block ending in ``catch (...)``. That machinery has to survive the build.
+Emscripten defaults to ``-sDISABLE_EXCEPTION_CATCHING=1``, which compiles every
+one of those handlers away and turns a throw into ``abort()`` -- so on that
+target the header's promise is not kept, and a caller parsing untrusted input
+gets a dead process instead of ``PVZSTD_E_NOMEM``.
+
+This project's own CMake therefore adds ``-fwasm-exceptions`` at compile and at
+link when ``EMSCRIPTEN`` is set, and adds it ``PUBLIC``: a wasm link cannot mix
+exception models, so a consumer compiling its own translation units against this
+library has to be on the same one. It is scoped to the target rather than set
+globally, so a project embedding this library keeps its own flags everywhere
+else. ``-fwasm-exceptions`` rather than the legacy JavaScript-based unwinder,
+which is slower, larger, and taxes every call site whether or not anything
+throws.
+
+A WebAssembly consumer that builds this library through some other build system
+must reproduce that flag, or the ABI silently stops returning statuses for the
+failures that matter most.
+
+
+Writing and appending
+---------------------
+
+The reading surface above is the one most consumers need. The header also
+carries three write-side surfaces, documented in place:
+
+* ``pvzstd_writer_*`` -- the container layer only. It takes arrays the caller
+  has already produced and emits the file; turning a dataset into arrays stays
+  with the caller. Reproducing the reference writer byte for byte needs the same
+  compression level *and* worker count, because zstd's threaded mode emits
+  different, equally valid bytes.
+* ``pvzstd_append_arrays`` -- add field arrays without rewriting the
+  container. Existing frames are copied by offset and never decompressed, so the
+  cost is what is added rather than the file size. Each call commits by rename,
+  so an interrupted append cannot damage what was there.
+* ``pvzstd_stream_*`` -- the same edit with the parsed state held open across
+  commits, so per-commit cost is flat in container size rather than growing with
+  it. The trade is crash behaviour: an interrupted stream commit leaves a trailer
+  describing frames that were not fully written. Use ``pvzstd_append_arrays``
+  when every commit must leave a valid file.
+
+
+A worked example
+----------------
+
+Open a container, read its first array, close. This is complete: it compiles as
+C, links against ``pvzstd::pvzstd``, and runs.
+
+.. code:: c
+
+   #include <pvzstd/pvzstd.h>
+
+   #include <stdio.h>
+   #include <stdlib.h>
+
+   int main(int argc, char **argv) {
+     if (argc != 2) {
+       fprintf(stderr, "usage: %s CONTAINER.pv\n", argv[0]);
+       return 2;
+     }
+
+     /* Proves a library actually linked, and that it is the one this header
+        describes: the two are compared for equality, not as a floor. */
+     if (pvzstd_abi_version() != PVZSTD_ABI_VERSION) {
+       fprintf(stderr, "pvzstd ABI mismatch: built against %u, linked %u\n",
+               (unsigned)PVZSTD_ABI_VERSION, pvzstd_abi_version());
+       return 1;
+     }
+
+     pvzstd_reader *reader = NULL;
+     uint32_t file_version = 0;
+     pvzstd_status status = pvzstd_open_versioned(argv[1], &reader, &file_version);
+     if (status != PVZSTD_OK) {
+       fprintf(stderr, "open: %s (container version %u, this build decodes %u)\n",
+               pvzstd_status_message(status), file_version, pvzstd_max_file_version());
+       return 1;
+     }
+
+     if (pvzstd_array_count(reader) == 0) {
+       fprintf(stderr, "container holds no arrays\n");
+       pvzstd_close(reader);
+       return 1;
+     }
+
+     pvzstd_array_info info;
+     status = pvzstd_array_info_at(reader, 0, &info);
+     if (status != PVZSTD_OK) {
+       fprintf(stderr, "info: %s\n", pvzstd_status_message(status));
+       pvzstd_close(reader);
+       return 1;
+     }
+
+     void *dst = malloc((size_t)info.nbytes);
+     if (dst == NULL && info.nbytes != 0) {
+       pvzstd_close(reader);
+       return 1;
+     }
+
+     status = pvzstd_read_array_at(reader, 0, dst, info.nbytes);
+     if (status != PVZSTD_OK) {
+       fprintf(stderr, "read: %s\n", pvzstd_status_message(status));
+       free(dst);
+       pvzstd_close(reader);
+       return 1;
+     }
+
+     printf("%s: dtype %s, ndim %u, %llu bytes\n", info.name, info.dtype,
+            (unsigned)info.ndim, (unsigned long long)info.nbytes);
+
+     free(dst);            /* the destination is the caller's */
+     pvzstd_close(reader); /* info.name and info.shape die here */
+     return 0;
+   }
+
+with
+
+.. code:: cmake
+
+   cmake_minimum_required(VERSION 3.16)
+   project(pvzstd_example LANGUAGES C)
+
+   find_package(pvzstd CONFIG REQUIRED)
+
+   add_executable(read_one read_one.c)
+   target_link_libraries(read_one PRIVATE pvzstd::pvzstd)
+
+Against a container written by ``pyvista_zstd.write``, it prints something like::
+
+   00007c31d6209960points: dtype <f4, ndim 2, 10104 bytes
+
+The UID prefix on the name is the dataset UID the format carries. It derives
+from an object address in the writing process, so it is not stable across
+processes and must be treated as an opaque token, never parsed for meaning.

--- a/doc/format/container-v2.md
+++ b/doc/format/container-v2.md
@@ -1,15 +1,27 @@
 # The `.pv` / `.zvtk` container — format specification
 
-Status: **DRAFT, derived by reading `src/pyvista_zstd/pyvista_zstd.py` at
-`6f1d021`.** Every claim below carries the line range it was read from.
-Claims that were _not_ verified against the source are marked **UNVERIFIED**
-and must be closed before the C++ core is written against them.
+Status: **Normative.** This is the specification the implementation is held
+to, not a description of it. Where the two disagree, this document and the
+conformance suite decide and the code is what changes.
 
-This document exists because the Python implementation is currently the only
-specification. A second implementation written against a reading rather than
-against a spec diverges silently, and the divergence surfaces in a user's
-file rather than in CI. The conformance corpus (`tests/conformance/`) is the
-executable half of this document; this prose is the reviewable half.
+It did not start that way. It was derived by reading
+`src/pyvista_zstd/pyvista_zstd.py` at `6f1d021`, when that module was the only
+implementation, and the line ranges every claim carries are that reading's
+provenance: they point into the file **as it stood at `6f1d021`** and are not
+current line numbers. The C++ core was then written against this document
+(`f88a1b5`), and `pyvista_zstd.py` is now a `ctypes` binding to that core
+rather than a second implementation of the format, so the direction has
+reversed.
+
+The conformance corpus (`tests/conformance/`) is the executable half of this
+document; this prose is the reviewable half. A second implementation written
+against a reading rather than against a spec diverges silently, and the
+divergence surfaces in a user's file rather than in CI.
+
+Two things this document does not cover, both of which shipped after it was
+written: the C ABI itself, which is documented in `doc/c_api.rst`, and the
+`pvzstd_` symbol names, which appear below only where the format's own rules
+are visible through them. Every question §9 once left open is now closed.
 
 ## 1. File layout
 
@@ -91,13 +103,24 @@ ImageData file with no attached arrays contains only the two metadata pairs.
 
 ### 1.1 Consequences that bind the implementation
 
-- **A writer must be able to seek.** The index and count can only be written
-  once every frame length is known. This is why the in-tree C++ writer
-  reopens with `r+b` to rewrite its tail. A write-only, forward-only sink is
-  not sufficient for this format.
+- **A writer must know every frame's length before it can emit the index**,
+  but it does not have to seek: the index goes last and its offsets are
+  cumulative ends, so a writer that accumulates them as it goes can stream the
+  body and then append the trailer. `pvzstd_writer_write` does exactly that --
+  one `wb` handle, frames written in order, trailer appended, close.
+  _Editing_ an existing container is where seeking becomes unavoidable, and
+  the two edit paths make opposite trades: `pvzstd_append_arrays` stages a
+  whole new file and commits it by rename, while `pvzstd_stream_append` holds
+  the original open `r+b`, overwrites the tail in place and truncates -- which
+  is why an interrupted stream commit can leave a trailer describing frames
+  that were not fully written, and an interrupted `pvzstd_append_arrays`
+  cannot.
 - **A reader must have the tail before it can read anything.** There is no
   forward-parseable stream: the index is mandatory and it lives at the end.
-  A reader over a non-seekable source must buffer the whole file.
+  A reader over a non-seekable source must buffer the whole file, which is
+  what `pvzstd_open_memory` exists to serve: it takes the whole container as
+  borrowed bytes the caller already holds and parses it in place, refusing a
+  crafted buffer wherever the path entry point would refuse a crafted file.
 - **The index entry width is 16 bytes and this is load-bearing.** It coincides
   with `UID_N_CHAR = 16` (`:120`), and the `EMPTY_DS` sentinel is a 16-character
   string specifically so it aligns with a UID (`:121`). Changing either
@@ -113,6 +136,15 @@ ImageData file with no attached arrays contains only the two metadata pairs.
 | 0     | `FILE_VERSION_UNFILTERED`        | Neither optional encoding used.                     |
 | 1     | `FILE_VERSION_SHUFFLE`           | At least one array carries the byte-shuffle filter. |
 | 2     | `FILE_VERSION_FIXED_WIDTH_CELLS` | Cell topology stored without an offsets array.      |
+
+A decoder must also have a ceiling. The C core carries one,
+`PVZSTD_FILE_VERSION_MAX = 2`, readable at runtime as
+`pvzstd_max_file_version()`, and a container stamped higher is refused with
+`PVZSTD_E_VERSION` rather than read: a later version may transform payloads in
+a way this build cannot invert, so reading one would hand back
+plausible-looking corrupt values instead of failing. The ceiling belongs beside
+the decoder it describes -- a binding that kept its own copy would refuse files
+the library can read, or accept files it cannot.
 
 The version is promoted by the _writer_ only when it actually uses an optional
 encoding — the `ZstdFileMetadata` default is the legacy
@@ -198,6 +230,30 @@ Because the UID derives from a Python object address, it is **not stable across
 processes** and must be treated as an opaque token, never parsed for meaning.
 Empty topology arrays are still written as full (header, payload) pairs with
 `shape=(0,)`.
+
+### 3.2 Every length in this header is file-supplied
+
+The bounds checks a parser writes around §3 are part of conforming to the
+format, not an optional hardening pass. `name_len` and `ndim` are 32-bit
+fields read out of the file, and a container can declare any value for either.
+Three rules, all implemented in `cpp/src/reader.cpp` and exercised by
+`tests/conformance/test_crafted_containers.py`:
+
+- **Check against the bytes that remain, by subtracting and dividing** rather
+  than by adding to an offset and multiplying. The offset is a `size_t`, 32
+  bits on a WebAssembly target, so `off + ndim * 8 + 16` wraps for an `ndim`
+  near 2^29 and turns the guard into a pass -- after which the shape loop reads
+  eight bytes per dimension past the end of the container.
+- **Refuse any field a `size_t` cannot hold** before it reaches an allocator.
+  Narrowing a 64-bit declared length on a 32-bit target asks for its low bits
+  and leaves the rest of the parse reasoning about the full value.
+- **Bound a declared decompressed size by what the frame could possibly
+  produce.** The index is file-supplied and unrelated to what the frame holds,
+  so a crafted entry can name any 64-bit number. A frame occupies only bytes
+  the container has, and zstd can expand each of those by at most 32768 (a
+  128 KiB block spelled as a 4-byte RLE block); anything above that product is
+  refused. Relying on the allocation to throw instead is not enough: a build
+  with exceptions compiled out cannot answer a throw.
 
 ## 4. Metadata
 
@@ -320,7 +376,7 @@ to align with the UID width.
 and writer entry points. Legacy files additionally use the
 `__zvtk_metadata` metadata key.
 
-## 9. Questions that were blocking the C++ core
+## 9. The questions that blocked the C++ core, and how they closed
 
 The first revision of this document listed four unresolved questions. Three are
 now closed by measurement against a live writer, not by re-reading the source.
@@ -344,17 +400,33 @@ now closed by measurement against a live writer, not by re-reading the source.
    and a writer may not emit them in a different order than `frame_names`
    (§1.2). Confirmed equal across all four dataset classes tested.
 
-4. **What is the append path's contract** when a file is extended
-   (`append.py`, 553 lines) — specifically whether the index is rewritten in
-   place or appended to. **STILL OPEN.** Note that `read_array` serves only
-   arrays appended through this path (`append.py:539` raises `KeyError` listing
-   an empty set for a plainly-written file), so the append surface is a
-   distinct namespace from the dataset arrays, not merely a different way in.
+4. **What is the append path's contract** when a file is extended —
+   specifically whether the index is rewritten in place or appended to.
+   **CLOSED — the index is rewritten whole.** An append cannot extend the
+   index, because the index is not what sits at the end: the frame count is.
+   The committed frames are copied verbatim by offset, never decompressed or
+   recompressed, the new frames are written after them, the two metadata frames
+   are regenerated, and a fresh full index and count are emitted. Cost is
+   therefore proportional to what is added, not to the size of the file.
+   `pvzstd_append_arrays` stages that into a new file and commits it by rename;
+   `pvzstd_stream_append` does it in place against the open original (§1.1).
+
+   The namespace question the first revision raised resolved the other way.
+   Appended arrays are ordinary arrays: their frames join the body and index,
+   their names join the file metadata, and they are registered as `field_data`
+   on the root dataset under the `…__field_data` suffix, so an ordinary read
+   surfaces them with no reader change. What is scoped to them is the _partial
+   read_ surface — `pvzstd_field_array_count` / `pvzstd_field_array_name_at` /
+   `pvzstd_find_field_array`, and `AppendReader` above them — which lists field
+   arrays only, and takes its list from the dataset metadata rather than by
+   scanning frame names for the suffix, since an ordinary array may end that
+   way too. MultiBlock has no single root dataset to append to and is refused
+   with `PVZSTD_E_UNSUPPORTED`.
 
 ### 9.1 How these were closed
 
-An independent reader (`refparse/ref_reader.py`) was written **only** from the
-byte layout, importing nothing from `pyvista_zstd`, so it could not inherit the
+An independent reader (`tests/conformance/ref_reader.py`) was written **only**
+from the byte layout, importing nothing from `pyvista_zstd`, so it could not inherit the
 library's assumptions. It reproduces every array bit-exactly (dtype, shape and
 contents) for PolyData, UnstructuredGrid, ImageData and StructuredGrid.
 
@@ -363,6 +435,16 @@ the filter branch never executed, so a green comparison said nothing about it.
 Re-running with `shuffle=True` exercised the branch, and disabling the
 unshuffle step as a negative control turned the comparison red on three arrays
 — which is what makes the green meaningful. **This reader is the conformance
-oracle for the C++ port; the C++ implementation must agree with it, and every
+oracle for the C++ core; the C++ implementation must agree with it, and every
 conformance case must include an input that actually reaches the branch under
-test.**
+test.** That is enforced rather than intended: `tests/conformance/` compares
+the core against it on every run.
+
+## 10. What this document leaves to the C ABI
+
+A few format-adjacent guarantees belong with the API rather than with the byte
+layout, and are specified in `doc/c_api.rst`: `pvzstd_open_memory`'s borrowing
+rules, the status enum, the promise that no exception crosses the boundary and
+what a WebAssembly build must be compiled with for that to hold, and
+`PVZSTD_ABI_VERSION`, which versions the _interface_ and is unrelated to the
+container `file_version` versioned in §2.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -23,4 +23,10 @@
    :maxdepth: 2
    :hidden:
 
+   c_api
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
    benchmarks/index


### PR DESCRIPTION
`README.rst` mentioned `pvzstd_`, `ABI` and `cmake` exactly zero times, and the toctree carried the README, examples, the Python API and benchmarks. So everything about the C library was discoverable only by reading `cpp/include/pvzstd/pvzstd.h`, which is thorough but is not documentation, and a consumer already exists.

## `doc/c_api.rst`

What the library is, and that the interface is pure C with zstd as its only dependency. The CMake build, with a table of the five options and the reasoning behind `vendored` against `system`. Both consumption paths, `find_package(pvzstd CONFIG)` and `add_subdirectory` or `FetchContent`, both yielding `pvzstd::pvzstd`, with the caveat that an installed STATIC library leaves zstd for the consumer to resolve.

`PVZSTD_ABI_VERSION` and that it is compared for equality rather than treated as a floor, alongside `pvzstd_abi_version()` as the accessor that proves a library actually loaded, since the macro compiles clean against one that never did. The separate `PVZSTD_FILE_VERSION_MAX` decode ceiling, which is a different thing and was easy to confuse with it.

The reading surface: opening from a path and from memory, who owns the borrowed buffer, and the hazard that modifying it under an open reader is undetected and yields wrong values rather than an error. Reader-owned `name` and `shape` lifetimes. Batch reads and `failed_slot`. The full status table with the note that two of the codes are refusals rather than damage, and the `-fwasm-exceptions` requirement for the status promise to hold on a WebAssembly build.

The worked example was extracted back out of the built page, compiled as C against a real install tree with the exact `CMakeLists.txt` the page shows, and run against a real container. It prints what the page says it prints, exits with `pvzstd_status_message` on a missing file, and is clean under `-Wall -Wextra`. The `add_subdirectory` path was checked the same way.

## The format specification was describing a world that ended

`doc/format/container-v2.md` still opened with `Status: DRAFT` and said its open questions "must be closed before the C++ core is written against them". The core landed in `f88a1b5` and six pull requests have shipped on top of it.

It is normative now, and says so. The core was written against it, and `tests/conformance/ref_reader.py` implements it as the oracle the parity tests compare against, while `pyvista_zstd.py` is a ctypes binding rather than a second implementation. The `6f1d021` line references are kept explicitly as provenance rather than passed off as current line numbers.

One claim in it was simply false. It said a writer must be able to seek, and that the in-tree C++ writer reopens with `r+b` to rewrite its tail. `pvzstd_writer_write` streams forward-only and appends the trailer at the end; the `r+b` reopen belongs to `pvzstd_stream_append`. Corrected.

Also corrected: `pvzstd_open_memory` added to the consequence about buffering a whole file, since a non-seekable source is now a first-class case rather than a hypothetical; the `PVZSTD_FILE_VERSION_MAX` and `PVZSTD_E_VERSION` decode ceiling added to section 2; a new section on the 32-bit hardening rules; section 9.4 closed, and its claim that appended arrays form a distinct namespace corrected, since they are ordinary arrays registered as `field_data` and it is only the partial-read surface that is field-scoped; and the `ref_reader.py` path fixed to `tests/conformance/`.

Docs build with the CI invocation under xvfb: four warnings, byte-identical to the baseline captured before any change. All four are pre-existing and none comes from these pages.
