### PR TITLE
Enforce one append at a time per container and widen the allocation handlers

### DIFF
--- a/cpp/include/pvzstd/pvzstd.h
+++ b/cpp/include/pvzstd/pvzstd.h
@@ -31,7 +31,7 @@ extern "C" {
 
 /* Bumped on any change below, additions included -- callers check equality, not
  * a floor, because they bind every symbol up front. */
-#define PVZSTD_ABI_VERSION 10u
+#define PVZSTD_ABI_VERSION 11u
 
 /* Dtype-field width and dataset-UID prefix width. They coincide in the format. */
 #define PVZSTD_DTYPE_LEN 16
@@ -50,7 +50,17 @@ typedef enum pvzstd_status {
    * PVZSTD_E_FORMAT has to report a well-formed container as corrupt. */
   PVZSTD_E_UNSUPPORTED = 8, /* the container is a shape this operation cannot serve */
   PVZSTD_E_EXISTS = 9,      /* the name is already taken, and would be overwritten */
-  PVZSTD_E_VERSION = 10     /* the container's file_version is newer than this build decodes */
+  PVZSTD_E_VERSION = 10,    /* the container's file_version is newer than this build decodes */
+  /* Another append holds this container. Nothing was written; the container is
+   * intact and the same call made again once the other one finishes succeeds.
+   * Also what a lock left behind by a killed append reports, which retrying
+   * does not clear -- see the Append section for the file to remove. */
+  PVZSTD_E_BUSY = 11,
+  /* The file changed under the operation, which had staged its result against
+   * what it read. Nothing was written; the same call made again reads what is
+   * there now and succeeds. Distinct from PVZSTD_E_IO because it is the one
+   * failure here that retrying is the right answer to. */
+  PVZSTD_E_CHANGED = 12
 } pvzstd_status;
 
 /* An out-parameter that names which of a call's own arrays a status is about
@@ -318,6 +328,40 @@ PVZSTD_API pvzstd_status pvzstd_writer_write(pvzstd_writer *writer, const char *
  * by offset, never decompressed, so the cost is what is added rather than the
  * file size; only the two metadata frames are regenerated. Each append commits
  * by rename, so an interrupted one cannot damage what was there.
+ *
+ * One append at a time, per container, and that is enforced rather than
+ * documented. An append is a read-modify-write: it reads the container, adds
+ * to what it read, and commits the result. Two of them running at once each
+ * commit "what was there plus mine", and the second to land replaces the
+ * first's arrays with a body copied before those arrays existed -- with both
+ * callers told they succeeded. Checking at the end does not recover that: two
+ * appends doing equal work reach their commits within microseconds of each
+ * other, so neither check sees the other's result yet.
+ *
+ * The exclusion is an advisory lock file, "<path>.append.lock", created
+ * exclusively and held for the call. A second append meanwhile returns
+ * PVZSTD_E_BUSY at once, having read and written nothing; it does not wait,
+ * because a library has no business choosing how long its caller blocks.
+ * Exclusive file creation is the primitive because it is the one every target
+ * this builds for implements the same way -- flock() would be the obvious
+ * choice and on the WebAssembly target it returns success without locking
+ * anything, which is a guarantee stated for a target that does not keep it.
+ *
+ * The cost is a lock that outlives a killed process: an append that dies
+ * between taking the lock and finishing leaves the file behind, and every
+ * later append to that container returns PVZSTD_E_BUSY until it is deleted.
+ * That is deliberate. It is a visible, named, recoverable failure, where what
+ * it replaces was one writer's arrays disappearing silently. Deleting the file
+ * is safe whenever no append is running.
+ *
+ * The lock binds appends and nothing else. A caller that replaces the
+ * container by other means -- another tool, or a plain move onto the path --
+ * is caught separately: each call stages into a file the operating system
+ * names, so no two callers are handed the same staging file, and before
+ * committing, a call checks that its path still names the container it read.
+ * One replaced during the staging returns PVZSTD_E_CHANGED having written
+ * nothing. That one is a check and not a lock, and covers the staging rather
+ * than the microseconds between the check and the rename.
  * ------------------------------------------------------------------ */
 
 /* One array to append. The format records two dtype spellings for the same array
@@ -350,6 +394,11 @@ typedef struct pvzstd_append_array {
  * so nothing decoding the file depends on it. PVZSTD_LEVEL_FROM_FILE keeps the
  * two in agreement and is what a caller wanting one level should pass.
  *
+ * PVZSTD_E_BUSY means another append holds this container, or a killed one left
+ * "<path>.append.lock" behind. PVZSTD_E_CHANGED means something that does not
+ * take that lock replaced the container while this call was staging its result.
+ * Neither wrote anything. See the section comment above.
+ *
  * The two refusals say what they are about rather than only that they happened,
  * both optional. On PVZSTD_E_EXISTS `clash_slot` receives the index into `arrays`
  * of the offered name that was already taken -- by the file or by an earlier
@@ -377,6 +426,12 @@ PVZSTD_API pvzstd_status pvzstd_append_arrays(const char *path, const pvzstd_app
  * by rename, whereas an interrupted stream commit leaves a trailer describing
  * frames that were not fully written. Use pvzstd_append_arrays when every commit
  * must leave a valid file.
+ *
+ * A stream takes no lock and is covered by none: it writes into the container
+ * in place, so it has neither a commit point at which to notice another writer
+ * nor a staging file to hold back, and PVZSTD_E_BUSY and PVZSTD_E_CHANGED are
+ * not among the statuses it can return. One stream at a time, and no append
+ * against the same container while it is open, is the caller's to arrange.
  * ------------------------------------------------------------------ */
 
 typedef struct pvzstd_stream pvzstd_stream;

--- a/cpp/src/append.cpp
+++ b/cpp/src/append.cpp
@@ -174,8 +174,23 @@ pvzstd_status pvzstd_append_arrays(const char *path, const pvzstd_append_array *
     if (!ParseDtype(a.dtype).valid) return PVZSTD_E_INVALID;
   }
 
+  // Held for the whole read-modify-write below, and released by its destructor
+  // on every way out of this function. Without it two appends both read the
+  // container, both add their own arrays to what they read, and the second to
+  // commit replaces the first one's result -- a lost update, which no amount of
+  // checking at the end can turn back into two writes.
+  AppendLock lock;
+  const LockResult locked = lock.Acquire(path);
+  if (locked == LockResult::kHeld) return PVZSTD_E_BUSY;
+  if (locked != LockResult::kAcquired) return PVZSTD_E_IO;
+
   ScopedFile src(std::fopen(path, "rb"));
   if (src.get() == nullptr) return PVZSTD_E_IO;
+  // Which file `path` names right now. Everything below is staged against this
+  // one, and step 7 checks that it is still the file being replaced. The lock
+  // covers the appends that take it; this covers everything else that can
+  // replace a file.
+  const FileIdentity opened_as = IdentifyOpen(src.get());
 
   std::vector<FrameEntry> frames;
   uint64_t body_end = 0;
@@ -365,8 +380,12 @@ pvzstd_status pvzstd_append_arrays(const char *path, const pvzstd_append_array *
   }
 
   // 7. Commit by rename, so an interrupted append cannot damage what was there.
-  const std::string tmp_path = std::string(path) + ".append.tmp";
-  ScopedFile out(std::fopen(tmp_path.c_str(), "wb"));
+  //    The staging file is named by the OS rather than derived from `path`: a
+  //    name derived from the container is the same name for every caller, so
+  //    two appends running at once both write into it and the file the rename
+  //    commits is a mixture of the two.
+  std::string tmp_path;
+  ScopedFile out(OpenUniqueTemp(path, src.get(), &tmp_path));
   if (out.get() == nullptr) return PVZSTD_E_IO;
 
   std::vector<uint8_t> chunk;
@@ -410,6 +429,20 @@ pvzstd_status pvzstd_append_arrays(const char *path, const pvzstd_append_array *
   if (!ok) {
     std::remove(tmp_path.c_str());
     return PVZSTD_E_IO;
+  }
+
+  // Still the container this call read? A writer that does not take the lock --
+  // another tool, or a plain move onto this path -- has a result that this
+  // rename would replace with a body copied before that result existed. A
+  // rename swaps the directory entry, so the file `path` names is no longer the
+  // file open here.
+  //
+  // This is a check and not a second lock: it catches a replacement made while
+  // this call was staging, which is the whole slow part, and not one made in
+  // the microseconds between here and the rename below.
+  if (!SameFile(opened_as, IdentifyPath(path))) {
+    std::remove(tmp_path.c_str());
+    return PVZSTD_E_CHANGED;
   }
 
   // Windows will not rename onto an open handle, and the source is still open.

--- a/cpp/src/append.cpp
+++ b/cpp/src/append.cpp
@@ -54,10 +54,19 @@ struct FrameEntry {
 };
 
 bool ReadAt(std::FILE *fp, uint64_t offset, uint64_t len, std::vector<uint8_t> *out) {
+  // Every caller's `len` is bounded by the container's own length, which is not
+  // itself bounded by size_t on a 32-bit target: a container larger than the
+  // address space would be read into the low bits of its length. Refusing it
+  // here also bounds the frame count, whose table is read through this call --
+  // a count past size_t needs a table of 16 times it, which cannot pass.
+  if (ExceedsSizeT(len)) return false;
   if (SeekTo(fp, static_cast<int64_t>(offset), SEEK_SET) != 0) return false;
   try {
     out->resize(static_cast<size_t>(len));
-  } catch (const std::bad_alloc &) {
+  } catch (const std::exception &) {
+    // Wider than std::bad_alloc on purpose: an oversized resize() throws
+    // std::length_error, which is not a bad_alloc, so the narrower handler let
+    // it out of the library.
     return false;
   }
   return len == 0 || std::fread(out->data(), 1, static_cast<size_t>(len), fp) == len;
@@ -105,9 +114,15 @@ pvzstd_status DecompressFrame(std::FILE *fp, const std::vector<FrameEntry> &fram
   std::vector<uint8_t> raw;
   if (!ReadAt(fp, start, len, &raw)) return PVZSTD_E_IO;
   std::string plain;
+  // The trailer's decompressed size is a file-supplied 64-bit field that
+  // ReadFooter has no way to check against the frame's contents, so a crafted
+  // container can name any number here. Narrowing it would ask for its low bits
+  // and then compare the result against a size the parse still believes.
+  if (ExceedsSizeT(frames[index].decomp)) return PVZSTD_E_FORMAT;
   try {
     plain.resize(static_cast<size_t>(frames[index].decomp));
-  } catch (const std::bad_alloc &) {
+  } catch (const std::exception &) {
+    // See ReadAt: std::length_error is not a std::bad_alloc.
     return PVZSTD_E_NOMEM;
   }
   const size_t got = ZSTD_decompress(plain.data(), plain.size(), raw.data(), raw.size());
@@ -149,6 +164,12 @@ pvzstd_status pvzstd_append_arrays(const char *path, const pvzstd_append_array *
     if (a.name == nullptr || a.dtype == nullptr || a.dtype_name == nullptr) return PVZSTD_E_INVALID;
     if (a.ndim > 0 && a.shape == nullptr) return PVZSTD_E_INVALID;
     if (a.nbytes > 0 && a.data == nullptr) return PVZSTD_E_INVALID;
+    // The payload buffer is sized from the narrowed nbytes while ShuffleBytes is
+    // driven from the full 64-bit one, so a length past size_t writes the shape
+    // of the whole array into a buffer holding its low bits. No caller can own
+    // that many bytes on a target where the check is live, so it is a bad
+    // argument rather than a shortage.
+    if (ExceedsSizeT(a.nbytes)) return PVZSTD_E_INVALID;
     if (std::strlen(a.dtype) > PVZSTD_DTYPE_LEN) return PVZSTD_E_INVALID;
     if (!ParseDtype(a.dtype).valid) return PVZSTD_E_INVALID;
   }
@@ -290,7 +311,8 @@ pvzstd_status pvzstd_append_arrays(const char *path, const pvzstd_append_array *
         }
       }
       plain.push_back(std::move(payload));
-    } catch (const std::bad_alloc &) {
+    } catch (const std::exception &) {
+      // See ReadAt: std::length_error is not a std::bad_alloc.
       return PVZSTD_E_NOMEM;
     }
     final_names.push_back(frame_name);
@@ -326,7 +348,10 @@ pvzstd_status pvzstd_append_arrays(const char *path, const pvzstd_append_array *
     plain.push_back(
         PackArrayMetadata(kFileMetadataKey, "|u1", {file_new.size()}, PVZSTD_FILTER_NONE));
     plain.emplace_back(file_new.begin(), file_new.end());
-  } catch (const std::bad_alloc &) {
+  } catch (const std::exception &) {
+    // See ReadAt: std::length_error is not a std::bad_alloc. No guard in front
+    // of this one -- both documents are already-allocated std::strings, so
+    // there is no 64-bit field to narrow.
     return PVZSTD_E_NOMEM;
   }
 

--- a/cpp/src/detail.h
+++ b/cpp/src/detail.h
@@ -28,6 +28,20 @@ constexpr int kMaxManualThreads = 8;
 constexpr uint64_t kBytesPerMiB = 1024ull * 1024ull;
 constexpr uint64_t kThreadBytesPerWorker = 2ull;  // floor(MiB / 2) workers
 
+// Whether a 64-bit length is too large to be held in a size_t. Always false
+// where size_t is 64 bits; on a 32-bit target -- and a WebAssembly build is one
+// -- it is what stops a length from wrapping as it is narrowed, or from being
+// silently truncated into a smaller allocation than the value the code around
+// it is still reasoning about.
+constexpr bool ExceedsSizeT(uint64_t v) {
+  if constexpr (sizeof(size_t) >= sizeof(uint64_t)) {
+    (void)v;
+    return false;
+  } else {
+    return v > static_cast<uint64_t>(SIZE_MAX);
+  }
+}
+
 inline void StoreU32(std::vector<uint8_t> *out, uint32_t v) {
   for (int i = 0; i < 4; ++i) out->push_back(static_cast<uint8_t>((v >> (8 * i)) & 0xFF));
 }
@@ -129,10 +143,19 @@ inline int EffectiveWorkers(int threads) {
 
 inline pvzstd_status CompressFrame(const uint8_t *src, uint64_t n, int level, int workers,
                                    std::vector<uint8_t> *out) {
+  // `n` is narrowed twice below -- into the bound and into the compress call --
+  // so a length past size_t would compress the low bits of the payload and emit
+  // a frame holding fewer bytes than the trailer records for it. Refused here
+  // rather than at each caller: every one of them ends up in this narrowing.
+  if (ExceedsSizeT(n)) return PVZSTD_E_INVALID;
   const size_t bound = ZSTD_compressBound(static_cast<size_t>(n));
   try {
     out->resize(bound);
-  } catch (const std::bad_alloc &) {
+  } catch (const std::exception &) {
+    // Wider than std::bad_alloc on purpose: an oversized resize() throws
+    // std::length_error, which is not a bad_alloc, so the narrower handler let
+    // it out past the fopen'd output file this runs under and left the entry
+    // point's catch(...) to answer with the file still open.
     return PVZSTD_E_NOMEM;
   }
 

--- a/cpp/src/fileio.h
+++ b/cpp/src/fileio.h
@@ -42,6 +42,21 @@ inline int64_t TellAt(std::FILE *fp) {
 #endif
 }
 
+// Whether a path is there, asked without opening it.
+//
+// Opening it is not a way to ask this. A handle on a file, even one held for an
+// instant and only for reading, is enough to make another process's delete of
+// that file fail on Windows, and the one file this is asked about is the append
+// lock, whose holder deletes it to release it.
+inline bool PathExists(const char *path) {
+#if defined(_WIN32)
+  return GetFileAttributesA(path) != INVALID_FILE_ATTRIBUTES;
+#else
+  struct stat st{};
+  return ::stat(path, &st) == 0;
+#endif
+}
+
 // The append lock for one container: a file beside it that exists only while an
 // append is in flight.
 //
@@ -65,6 +80,9 @@ enum class LockResult {
 
 class AppendLock {
  public:
+  // Retries of the exclusive create, spent only on a lock seen to be gone.
+  static constexpr int kAcquireAttempts = 8;
+
   AppendLock() = default;
   ~AppendLock() { Release(); }
   AppendLock(const AppendLock &) = delete;
@@ -72,23 +90,33 @@ class AppendLock {
 
   LockResult Acquire(const std::string &container) {
     const std::string lock = container + ".append.lock";
-    // "x" fails if the file exists, and creating-if-absent is one operation:
-    // testing first and creating second is the race this is here to close.
-    std::FILE *fp = std::fopen(lock.c_str(), "wbx");
-    if (fp == nullptr) {
+    for (int attempt = 0; attempt < kAcquireAttempts; ++attempt) {
+      // "x" fails if the file exists, and creating-if-absent is one operation:
+      // testing first and creating second is the race this is here to close.
+      std::FILE *fp = std::fopen(lock.c_str(), "wbx");
+      if (fp != nullptr) {
+        std::fclose(fp);
+        path_ = lock;
+        return LockResult::kAcquired;
+      }
       // Held, or unwritable? Told apart by whether the lock is there rather
       // than by errno, whose value for an exclusive create onto an existing
       // file is not the same number on every target. A caller told "another
       // append holds this" about a directory it cannot write to would go
       // looking for a writer that does not exist.
-      std::FILE *probe = std::fopen(lock.c_str(), "rb");
-      if (probe == nullptr) return LockResult::kFailed;
-      std::fclose(probe);
-      return LockResult::kHeld;
+      if (PathExists(lock.c_str())) return LockResult::kHeld;
+      // Neither: the holder released the lock in the moment between the create
+      // and the question, so this call lost a race rather than found a broken
+      // directory, and the create is worth making again. Reporting the empty
+      // answer as a failure is how ordinary contention turned into an I/O
+      // error, which is the one outcome a losing append must never get.
+      //
+      // Bounded, because a create that keeps failing over a lock that is never
+      // there is a directory this process cannot write to. Contention resolves
+      // inside the bound: whoever is racing here either creates the file or
+      // finds somebody else's.
     }
-    std::fclose(fp);
-    path_ = lock;
-    return LockResult::kAcquired;
+    return LockResult::kFailed;
   }
 
   void Release() {

--- a/cpp/src/fileio.h
+++ b/cpp/src/fileio.h
@@ -1,15 +1,26 @@
-// 64-bit file positioning. std::fseek/ftell use `long`, 32 bits on Windows and
-// 32-bit targets, so past 2 GiB the offset wraps and the trailer is read from the
-// wrong place. The POSIX branch needs _FILE_OFFSET_BITS=64, set in CMakeLists.
+// 64-bit file positioning, unique staging files, and file identity.
+//
+// std::fseek/ftell use `long`, 32 bits on Windows and 32-bit targets, so past
+// 2 GiB the offset wraps and the trailer is read from the wrong place. The POSIX
+// branch needs _FILE_OFFSET_BITS=64, set in CMakeLists.
 
 #ifndef PVZSTD_FILEIO_H
 #define PVZSTD_FILEIO_H
 
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
 
 #if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <io.h>
+#include <windows.h>
+#else
+#include <sys/stat.h>
+#include <unistd.h>
 #endif
 
 namespace pvzstd::detail {
@@ -30,6 +41,194 @@ inline int64_t TellAt(std::FILE *fp) {
   return static_cast<int64_t>(::ftello(fp));
 #endif
 }
+
+// The append lock for one container: a file beside it that exists only while an
+// append is in flight.
+//
+// Exclusive creation is the primitive because it is the only form of mutual
+// exclusion every target this builds for implements the same way. flock() would
+// be the obvious choice and is not usable here: on the WebAssembly target it
+// returns success without locking anything, so a second holder is handed the
+// lock the first one thinks it has -- a guarantee stated for a target that does
+// not keep it is worse than none, because it is the one nobody re-checks.
+//
+// The cost of doing it with a file is that a process killed mid-append leaves
+// the lock behind, and every later append to that container is refused until it
+// is removed. That is a visible, named, recoverable failure; the alternative it
+// replaces is one writer's arrays disappearing with both writers told they
+// succeeded.
+enum class LockResult {
+  kAcquired,
+  kHeld,   // somebody else has this container
+  kFailed  // the lock file could not be created at all
+};
+
+class AppendLock {
+ public:
+  AppendLock() = default;
+  ~AppendLock() { Release(); }
+  AppendLock(const AppendLock &) = delete;
+  AppendLock &operator=(const AppendLock &) = delete;
+
+  LockResult Acquire(const std::string &container) {
+    const std::string lock = container + ".append.lock";
+    // "x" fails if the file exists, and creating-if-absent is one operation:
+    // testing first and creating second is the race this is here to close.
+    std::FILE *fp = std::fopen(lock.c_str(), "wbx");
+    if (fp == nullptr) {
+      // Held, or unwritable? Told apart by whether the lock is there rather
+      // than by errno, whose value for an exclusive create onto an existing
+      // file is not the same number on every target. A caller told "another
+      // append holds this" about a directory it cannot write to would go
+      // looking for a writer that does not exist.
+      std::FILE *probe = std::fopen(lock.c_str(), "rb");
+      if (probe == nullptr) return LockResult::kFailed;
+      std::fclose(probe);
+      return LockResult::kHeld;
+    }
+    std::fclose(fp);
+    path_ = lock;
+    return LockResult::kAcquired;
+  }
+
+  void Release() {
+    if (path_.empty()) return;
+    std::remove(path_.c_str());
+    path_.clear();
+  }
+
+ private:
+  std::string path_;
+};
+
+// Which file something is, as opposed to which name it goes by.
+//
+// A rename replaces a directory entry, so a path that named one file before a
+// concurrent writer committed names a different file afterwards while the
+// handle already open still refers to the old one. Comparing these two answers
+// is how an edit staged against the old file notices it is about to overwrite
+// somebody else's.
+struct FileIdentity {
+  bool known = false;  // false where the filesystem could not answer
+  uint64_t volume = 0;
+  uint64_t file = 0;
+};
+
+// Whether two identities name the same file. An unanswered identity compares
+// equal to everything on purpose: the callers use this to refuse an edit, and a
+// filesystem that reports nothing useful must not turn that into a refusal of
+// every edit.
+inline bool SameFile(const FileIdentity &a, const FileIdentity &b) {
+  if (!a.known || !b.known) return true;
+  return a.volume == b.volume && a.file == b.file;
+}
+
+#if defined(_WIN32)
+
+inline FileIdentity IdentifyHandle(HANDLE handle) {
+  FileIdentity id;
+  BY_HANDLE_FILE_INFORMATION info;
+  if (handle != INVALID_HANDLE_VALUE && GetFileInformationByHandle(handle, &info) != 0) {
+    id.known = true;
+    id.volume = info.dwVolumeSerialNumber;
+    id.file = (static_cast<uint64_t>(info.nFileIndexHigh) << 32) | info.nFileIndexLow;
+  }
+  return id;
+}
+
+inline FileIdentity IdentifyOpen(std::FILE *fp) {
+  if (fp == nullptr) return FileIdentity{};
+  const intptr_t raw = _get_osfhandle(_fileno(fp));
+  if (raw == -1) return FileIdentity{};
+  return IdentifyHandle(reinterpret_cast<HANDLE>(raw));
+}
+
+inline FileIdentity IdentifyPath(const char *path) {
+  // Every sharing mode: this only reads the file's identity, and refusing to
+  // answer because somebody else has it open would defeat the point.
+  HANDLE handle = CreateFileA(path, 0, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                              nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+  if (handle == INVALID_HANDLE_VALUE) return FileIdentity{};
+  const FileIdentity id = IdentifyHandle(handle);
+  CloseHandle(handle);
+  return id;
+}
+
+// Create and open a staging file beside `path`, named by the OS rather than
+// derived from `path`: two callers staging an edit to one container must never
+// be handed the same name, or each writes into the other's file. `model` is
+// ignored here -- a new file inherits its ACL from the directory.
+inline std::FILE *OpenUniqueTemp(const std::string &path, std::FILE *model, std::string *tmp_path) {
+  (void)model;
+  const size_t cut = path.find_last_of("\\/");
+  const std::string dir = (cut == std::string::npos) ? std::string(".") : path.substr(0, cut + 1);
+  char name[MAX_PATH];
+  // GetTempFileName creates the file, so no second caller can be handed the
+  // name it just returned.
+  if (GetTempFileNameA(dir.c_str(), "pvz", 0, name) == 0) return nullptr;
+  std::FILE *fp = std::fopen(name, "wb");
+  if (fp == nullptr) {
+    std::remove(name);
+    return nullptr;
+  }
+  *tmp_path = name;
+  return fp;
+}
+
+#else
+
+inline FileIdentity IdentifyOpen(std::FILE *fp) {
+  FileIdentity id;
+  struct stat st{};
+  if (fp != nullptr && ::fstat(::fileno(fp), &st) == 0) {
+    id.known = true;
+    id.volume = static_cast<uint64_t>(st.st_dev);
+    id.file = static_cast<uint64_t>(st.st_ino);
+  }
+  return id;
+}
+
+inline FileIdentity IdentifyPath(const char *path) {
+  FileIdentity id;
+  struct stat st{};
+  if (::stat(path, &st) == 0) {
+    id.known = true;
+    id.volume = static_cast<uint64_t>(st.st_dev);
+    id.file = static_cast<uint64_t>(st.st_ino);
+  }
+  return id;
+}
+
+// See the Windows arm. mkstemp is what makes the name unique here: it creates
+// the file itself, so the name it returns is one no other caller can be given.
+// A suffix built from the process id and a counter would be simpler and would
+// hold on Linux, macOS and Windows -- but not on the WebAssembly target, where
+// getpid() is a fixed stub value and every process would build the same suffix.
+//
+// `model`, when not NULL, is an open handle on the file this one will replace.
+// mkstemp opens 0600, so committing the staging file without copying the mode
+// across would tighten the container's permissions behind the caller's back.
+inline std::FILE *OpenUniqueTemp(const std::string &path, std::FILE *model, std::string *tmp_path) {
+  const std::string tmpl = path + ".append.XXXXXX";
+  std::vector<char> name(tmpl.begin(), tmpl.end());
+  name.push_back('\0');
+  const int fd = ::mkstemp(name.data());
+  if (fd < 0) return nullptr;
+  struct stat st{};
+  if (model != nullptr && ::fstat(::fileno(model), &st) == 0) {
+    ::fchmod(fd, st.st_mode & 07777);
+  }
+  std::FILE *fp = ::fdopen(fd, "wb");
+  if (fp == nullptr) {
+    ::close(fd);
+    std::remove(name.data());
+    return nullptr;
+  }
+  *tmp_path = name.data();
+  return fp;
+}
+
+#endif
 
 }  // namespace pvzstd::detail
 

--- a/cpp/src/fileio.h
+++ b/cpp/src/fileio.h
@@ -165,7 +165,7 @@ inline std::FILE *OpenUniqueTemp(const std::string &path, std::FILE *model, std:
   char name[MAX_PATH];
   // GetTempFileName creates the file, so no second caller can be handed the
   // name it just returned.
-  if (GetTempFileNameA(dir.c_str(), "pvz", 0, name) == 0) return nullptr;
+  if (GetTempFileNameA(dir.c_str(), "zst", 0, name) == 0) return nullptr;
   std::FILE *fp = std::fopen(name, "wb");
   if (fp == nullptr) {
     std::remove(name);

--- a/cpp/src/reader.cpp
+++ b/cpp/src/reader.cpp
@@ -42,19 +42,11 @@ constexpr char kMultiblockSuffix[] = "__multiblock__ds_metadata";
 constexpr char kFieldDataSuffix[] = "__field_data";
 constexpr size_t kUidNChar = 16;
 
-// Whether a 64-bit field out of the container is too large to be held in a
-// size_t. Always false where size_t is 64 bits; on a 32-bit target -- and a
-// WebAssembly build is one -- it is what stops a file-supplied length from
-// wrapping as it is narrowed, or from being silently truncated into a smaller
-// allocation than the value the rest of the parse is still reasoning about.
-constexpr bool ExceedsSizeT(uint64_t v) {
-  if constexpr (sizeof(size_t) >= sizeof(uint64_t)) {
-    (void)v;
-    return false;
-  } else {
-    return v > static_cast<uint64_t>(SIZE_MAX);
-  }
-}
+// Lives in detail.h now: the write, append and stream paths narrow file- and
+// caller-supplied lengths into allocations of their own, and one definition is
+// what keeps the four answers the same. Named here so the uses below read as
+// they did.
+using pvzstd::detail::ExceedsSizeT;
 
 // The most a zstd frame can expand, per compressed byte. A zstd block covers at
 // most 128 KiB, and the cheapest way to spell one is an RLE block: a 3-byte

--- a/cpp/src/reader.cpp
+++ b/cpp/src/reader.cpp
@@ -879,6 +879,10 @@ const char *pvzstd_status_message(pvzstd_status status) {
       return "an array of that name is already in the container";
     case PVZSTD_E_VERSION:
       return "the container's file version is newer than this build can decode";
+    case PVZSTD_E_BUSY:
+      return "another append holds this container, or left its lock file behind";
+    case PVZSTD_E_CHANGED:
+      return "another writer replaced the container while this call was staging its result";
   }
   return "unknown status";
 }

--- a/cpp/src/stream.cpp
+++ b/cpp/src/stream.cpp
@@ -94,10 +94,20 @@ pvzstd_status ReadFrame(pvzstd_stream *s, const std::vector<uint64_t> &ends,
   const uint64_t start = (index == 0) ? 0 : ends[index - 1];
   const uint64_t n = ends[index] - start;
   std::vector<uint8_t> comp;
+  // Both lengths come out of the trailer. The compressed one is bounded only by
+  // the container's own length, which is not itself bounded by size_t on a
+  // 32-bit target; the decompressed one is a field nothing checks against the
+  // frame's contents, so a crafted container can name any number. Narrowing
+  // either would allocate its low bits and then read or write against the value
+  // the parse still believes.
+  if (ExceedsSizeT(n) || ExceedsSizeT(sizes[index])) return PVZSTD_E_FORMAT;
   try {
     comp.resize(static_cast<size_t>(n));
     out->resize(static_cast<size_t>(sizes[index]));
-  } catch (const std::bad_alloc &) {
+  } catch (const std::exception &) {
+    // Wider than std::bad_alloc on purpose: an oversized resize() throws
+    // std::length_error, which is not a bad_alloc, so the narrower handler let
+    // it out past the cleanup this open does on every other failure.
     return PVZSTD_E_NOMEM;
   }
   if (SeekTo(s->fp, static_cast<int64_t>(start), SEEK_SET) != 0) return PVZSTD_E_IO;
@@ -132,7 +142,9 @@ pvzstd_status WriteTail(pvzstd_stream *s) {
     plain.push_back(
         PackArrayMetadata(kFileMetadataKey, "|u1", {file_new.size()}, PVZSTD_FILTER_NONE));
     plain.emplace_back(file_new.begin(), file_new.end());
-  } catch (const std::bad_alloc &) {
+  } catch (const std::exception &) {
+    // See ReadFrame. No guard in front: both documents are already-allocated
+    // std::strings, so there is no 64-bit field to narrow.
     return PVZSTD_E_NOMEM;
   }
 
@@ -197,6 +209,12 @@ pvzstd_status pvzstd_stream_open(const char *path, pvzstd_stream **out) try {
   // Bounded by division: n_frames comes from the file and n_frames * 16 overflows
   // for a large enough value.
   if (n_frames > (static_cast<uint64_t>(file_size) - 8) / 16) return fail(PVZSTD_E_FORMAT);
+  // The three vectors below are sized from the narrowed count and then indexed
+  // by a 64-bit loop counter, and the table is 16 bytes per frame -- so on a
+  // 32-bit target a count past size_t, or one whose table is, sizes them from
+  // the low bits and the loop writes past the end. Both are refused before
+  // anything is allocated.
+  if (ExceedsSizeT(n_frames) || ExceedsSizeT(n_frames * 16)) return fail(PVZSTD_E_FORMAT);
 
   std::vector<uint64_t> ends(static_cast<size_t>(n_frames));
   std::vector<uint64_t> sizes(static_cast<size_t>(n_frames));
@@ -204,7 +222,9 @@ pvzstd_status pvzstd_stream_open(const char *path, pvzstd_stream **out) try {
     std::vector<uint8_t> table;
     try {
       table.resize(static_cast<size_t>(n_frames) * 16);
-    } catch (const std::bad_alloc &) {
+    } catch (const std::exception &) {
+      // See ReadFrame: std::length_error is not a std::bad_alloc, and letting
+      // it past `fail` leaks this stream and the file it holds open.
       return fail(PVZSTD_E_NOMEM);
     }
     if (SeekTo(s->fp, -static_cast<int64_t>(table.size() + 8), SEEK_END) != 0) {
@@ -305,6 +325,11 @@ pvzstd_status pvzstd_stream_append(pvzstd_stream *s, const pvzstd_append_array *
     if (a.name == nullptr || a.dtype == nullptr || a.dtype_name == nullptr) return PVZSTD_E_INVALID;
     if (a.ndim > 0 && a.shape == nullptr) return PVZSTD_E_INVALID;
     if (a.nbytes > 0 && a.data == nullptr) return PVZSTD_E_INVALID;
+    // The payload buffer is sized from the narrowed nbytes while ShuffleBytes is
+    // driven from the full 64-bit one, so a length past size_t writes the shape
+    // of the whole array into a buffer holding its low bits. Same refusal
+    // pvzstd_append_arrays makes, for the same staging code.
+    if (ExceedsSizeT(a.nbytes)) return PVZSTD_E_INVALID;
     if (std::strlen(a.dtype) > PVZSTD_DTYPE_LEN) return PVZSTD_E_INVALID;
     if (!ParseDtype(a.dtype).valid) return PVZSTD_E_INVALID;
     for (const std::string &have : existing) {
@@ -360,7 +385,8 @@ pvzstd_status pvzstd_stream_append(pvzstd_stream *s, const pvzstd_append_array *
         }
       }
       pair.push_back(std::move(payload));
-    } catch (const std::bad_alloc &) {
+    } catch (const std::exception &) {
+      // See ReadFrame: std::length_error is not a std::bad_alloc.
       return Fail(s, PVZSTD_E_NOMEM);
     }
 

--- a/cpp/src/writer.cpp
+++ b/cpp/src/writer.cpp
@@ -56,6 +56,12 @@ pvzstd_status AddArray(pvzstd_writer *writer, const char *name, const char *dtyp
                        bool copy) {
   if (writer == nullptr || name == nullptr || dtype == nullptr) return PVZSTD_E_INVALID;
   if (nbytes > 0 && data == nullptr) return PVZSTD_E_INVALID;
+  // A borrowed entry keeps `nbytes` as a 64-bit length and hands it to
+  // ShuffleBytes at write time, while the shuffle destination is sized from the
+  // same value narrowed into a vector -- so a length past size_t writes the
+  // whole array into a buffer holding its low bits. No caller can own that many
+  // bytes on a target where the check is live, so it is a bad argument.
+  if (ExceedsSizeT(nbytes)) return PVZSTD_E_INVALID;
   if (ndim > 0 && shape == nullptr) return PVZSTD_E_INVALID;
   if (std::strlen(dtype) > PVZSTD_DTYPE_LEN) return PVZSTD_E_INVALID;
   if (!ParseDtype(dtype).valid) return PVZSTD_E_INVALID;
@@ -73,7 +79,10 @@ pvzstd_status AddArray(pvzstd_writer *writer, const char *name, const char *dtyp
       entry.borrowed_size = nbytes;
     }
     writer->arrays.push_back(std::move(entry));
-  } catch (const std::bad_alloc &) {
+  } catch (const std::exception &) {
+    // Wider than std::bad_alloc on purpose: an oversized allocation throws
+    // std::length_error, which is not a bad_alloc, so the narrower handler let
+    // it out of the library.
     return PVZSTD_E_NOMEM;
   }
   return PVZSTD_OK;
@@ -155,7 +164,9 @@ pvzstd_status pvzstd_writer_set_ds_metadata(pvzstd_writer *writer, const char *u
   try {
     entry.owned.assign(json, json + n);
     writer->arrays.push_back(std::move(entry));
-  } catch (const std::bad_alloc &) {
+  } catch (const std::exception &) {
+    // See AddArray. No guard in front: `n` is a strlen of a string the caller
+    // already holds, so it cannot name more bytes than exist.
     return PVZSTD_E_NOMEM;
   }
   return PVZSTD_OK;
@@ -220,7 +231,8 @@ pvzstd_status pvzstd_writer_write(pvzstd_writer *writer, const char *path) try {
   meta_entry.is_metadata_json = true;
   try {
     meta_entry.owned.assign(meta.begin(), meta.end());
-  } catch (const std::bad_alloc &) {
+  } catch (const std::exception &) {
+    // See AddArray. No guard in front: `meta` is a std::string built above.
     return PVZSTD_E_NOMEM;
   }
   // Local list, not the writer's own, so writing to a second path emits one

--- a/doc/c_api.rst
+++ b/doc/c_api.rst
@@ -163,7 +163,7 @@ The ABI version
 
 .. code:: c
 
-   #define PVZSTD_ABI_VERSION 10u
+   #define PVZSTD_ABI_VERSION 11u
    PVZSTD_API uint32_t pvzstd_abi_version(void);
 
 The macro is the version the caller compiled against; the function is the
@@ -384,10 +384,17 @@ a static, human-readable string and is never ``NULL``.
      - The name is already taken, and would be overwritten.
    * - ``PVZSTD_E_VERSION``
      - The container's ``file_version`` is newer than this build decodes.
+   * - ``PVZSTD_E_BUSY``
+     - Another append holds this container, or left its lock file behind.
+   * - ``PVZSTD_E_CHANGED``
+     - The container was replaced while this call was staging its result.
 
-The last three are refusals rather than damage: the file parsed, and the
-operation is the thing being declined. A caller that cannot tell them from
-``PVZSTD_E_FORMAT`` has to report a well-formed container as corrupt.
+Everything from ``PVZSTD_E_UNSUPPORTED`` down is a refusal rather than damage:
+the file parsed, and the operation is the thing being declined. A caller that
+cannot tell them from ``PVZSTD_E_FORMAT`` has to report a well-formed container
+as corrupt. The last two are further worth telling apart from ``PVZSTD_E_IO``,
+because nothing is wrong with the file or the disk and the call is worth making
+again -- see :ref:`c_api_append_lock`.
 
 .. _c_api_wasm_exceptions:
 
@@ -429,12 +436,85 @@ carries three write-side surfaces, documented in place:
 * ``pvzstd_append_arrays`` -- add field arrays without rewriting the
   container. Existing frames are copied by offset and never decompressed, so the
   cost is what is added rather than the file size. Each call commits by rename,
-  so an interrupted append cannot damage what was there.
+  so an interrupted append cannot damage what was there. It also takes a lock;
+  see :ref:`c_api_append_lock` below, which is the one thing on this page that
+  can leave a container needing a human.
 * ``pvzstd_stream_*`` -- the same edit with the parsed state held open across
   commits, so per-commit cost is flat in container size rather than growing with
   it. The trade is crash behaviour: an interrupted stream commit leaves a trailer
   describing frames that were not fully written. Use ``pvzstd_append_arrays``
   when every commit must leave a valid file.
+
+.. _c_api_append_lock:
+
+One append at a time
+~~~~~~~~~~~~~~~~~~~~
+
+An append is a read-modify-write: it reads the container, adds to what it read,
+and commits the result. Two of them running at once each commit "what was there
+plus mine", and the second to land replaces the first's arrays with a body
+copied before those arrays existed -- with both callers told they succeeded.
+Noticing that at the end does not work either: two appends doing equal work
+reach their commits within microseconds of each other, so neither one's check
+sees the other's result yet. Measured on four concurrent appends, three sets of
+arrays were lost in every run and every caller reported success.
+
+``pvzstd_append_arrays`` therefore takes an advisory lock for the duration of
+the call: a file named ``<path>.append.lock``, beside the container, created
+exclusively. A second append meanwhile returns ``PVZSTD_E_BUSY`` **immediately,
+rather than waiting.** It does not block, because a library has no business
+choosing how long its caller waits; retrying is the caller's decision, and a
+retry succeeds as soon as the other append finishes.
+
+Exclusive file creation is the primitive rather than ``flock`` because it is the
+one form of mutual exclusion every target this builds for implements the same
+way. On the WebAssembly target ``flock`` returns success without locking
+anything, so a second holder would be handed a lock the first one believes it
+has.
+
+.. warning::
+
+   **A killed append leaves its lock behind, and a human has to delete it.**
+   The lock file is removed when the call returns, however it returns -- but a
+   process that dies between taking it and finishing never gets to. Every later
+   append to that container then returns ``PVZSTD_E_BUSY`` until the file is
+   removed, and no retry clears it.
+
+   Recovery is deleting ``<path>.append.lock``. That is safe whenever no append
+   is actually running against the container; the file carries no state, and the
+   container itself was never touched by the append that died. The trade is
+   deliberate: this is a visible, named, recoverable failure, where what it
+   replaces was one writer's arrays disappearing with nothing reported.
+
+The lock binds appends and nothing else. A writer that does not take it --
+another tool, or a plain ``mv`` onto the path -- is caught separately: each
+append stages into a file the operating system names, so no two callers are ever
+handed the same staging file, and before committing, a call checks that its path
+still names the container it read. One replaced during the staging returns
+``PVZSTD_E_CHANGED`` having written nothing, and running it again picks up the
+other writer's result. That one is a check and not a lock: it covers the
+staging, which is the slow part, and not the microseconds between the check and
+the rename.
+
+Streams take no lock and are covered by none. ``pvzstd_stream_*`` writes into
+the container in place, so it has neither a commit point at which to notice
+another writer nor a staging file to hold back, and it returns neither
+``PVZSTD_E_BUSY`` nor ``PVZSTD_E_CHANGED``. One stream at a time, and no append
+against the same container while a stream is open, is the caller's to arrange.
+
+On WebAssembly
+^^^^^^^^^^^^^^
+
+The lock is real on that target, not inert: exclusive creation works under both
+Emscripten's own filesystems and ``NODERAWFS``, and a stale lock refuses a later
+append there exactly as it does natively. What it cannot do is protect a
+consumer against itself. A single-threaded module with no other writer never
+contends, so the lock costs it two filesystem operations per append and nothing
+else; two module instances sharing one real file through ``NODERAWFS`` are two
+writers and are excluded properly. Two instances over separate in-memory
+filesystems are not sharing a container at all, so there is nothing to exclude
+-- and if such a build ever loses a lock file to a discarded filesystem, the
+container is discarded with it.
 
 
 A worked example

--- a/src/pyvista_zstd/_capi.py
+++ b/src/pyvista_zstd/_capi.py
@@ -39,6 +39,8 @@ if TYPE_CHECKING:
 __all__ = [
     "ABI_VERSION",
     "ArrayExistsError",
+    "ContainerBusyError",
+    "ContainerChangedError",
     "ContainerFormatError",
     "ContainerShapeError",
     "CoreReader",
@@ -50,7 +52,7 @@ __all__ = [
     "max_file_version",
 ]
 
-ABI_VERSION = 10
+ABI_VERSION = 11
 """ABI this binding speaks. A library reporting anything else is refused."""
 
 DTYPE_LEN = 16
@@ -76,12 +78,15 @@ SHUFFLE_AUTO = 2
 _LIBRARY_ENV_VAR = "PVZSTD_LIBRARY"
 
 _STATUS_OK = 0
+_STATUS_IO = 1
 _STATUS_FORMAT = 2
 _STATUS_RANGE = 4
 _STATUS_FILTER = 6
 _STATUS_UNSUPPORTED = 8
 _STATUS_EXISTS = 9
 _STATUS_VERSION = 10
+_STATUS_BUSY = 11
+_STATUS_CHANGED = 12
 _STATUS_NAMES = {
     1: "I/O error: file missing, unreadable, or truncated",
     2: "format error: the trailer or a frame header did not parse",
@@ -93,6 +98,8 @@ _STATUS_NAMES = {
     8: "this operation cannot serve a container of that shape",
     9: "an array of that name is already in the container",
     10: "unsupported file version: the container is newer than this build decodes",
+    11: "another append holds this container, or left its lock file behind",
+    12: "the container was replaced by another writer while this call was staging its result",
 }
 
 
@@ -151,6 +158,28 @@ class UnsupportedFileVersionError(PvzstdError, ValueError):
         )
         self.found = found
         self.supported = supported
+
+
+class ContainerBusyError(PvzstdError):
+    """
+    Another append holds this container.
+
+    One append runs against a container at a time, enforced with a lock file
+    beside it. Nothing was read or written; the same call works once the other
+    append finishes. An append killed mid-flight leaves the lock behind, which
+    reports the same way and is cleared by deleting the file the message names.
+    """
+
+
+class ContainerChangedError(PvzstdError):
+    """
+    The container was replaced while this call was staging its result.
+
+    Raised for a writer that does not take the append lock -- another tool, or
+    a move onto the path. Named separately because repeating the call is the
+    right answer to it: nothing was written, and a second attempt reads what is
+    on disk now.
+    """
 
 
 class ContainerShapeError(PvzstdError, NotImplementedError):
@@ -1024,6 +1053,24 @@ def append_arrays(
         )
     if status == _STATUS_UNSUPPORTED:
         raise ContainerShapeError(status, message="appending to MultiBlock .pv files is not supported.")
+    if status == _STATUS_BUSY:
+        raise ContainerBusyError(
+            status,
+            message=(
+                f"another append holds {Path(path).name}; nothing was written. One append runs "
+                f"against a container at a time. If no other append is running, an earlier one was "
+                f"killed and left {Path(path).name}.append.lock behind; delete it and try again."
+            ),
+        )
+    if status == _STATUS_CHANGED:
+        raise ContainerChangedError(
+            status,
+            message=(
+                f"{Path(path).name} was replaced by another writer while this append was staging its "
+                "result; nothing was written. append_arrays is single-writer -- serialise the writers, "
+                "or retry to append on top of what is there now."
+            ),
+        )
     _check(status, str(path))
 
 

--- a/tests/conformance/container_surgery.py
+++ b/tests/conformance/container_surgery.py
@@ -1,0 +1,40 @@
+"""
+Take a written container apart and put it back together.
+
+Shared by the test modules that assert what the core does with a container it
+was not given: both of them need the same two operations -- split the file into
+its frames and their trailer entries, and re-emit the trailer over whatever the
+frames became -- and a second copy of the trailer layout is a second chance to
+write the tests against a format the library does not use.
+"""
+
+from __future__ import annotations
+
+import struct
+
+INDEX_ENTRY_SIZE = 16
+"""Bytes per trailer index entry: two little-endian u64 fields."""
+
+
+def split_frames(raw: bytes) -> list[list]:
+    """Return ``[compressed_bytes, declared_size]`` per frame, in file order."""
+    (n_frames,) = struct.unpack("<Q", raw[-8:])
+    index_off = len(raw) - 8 - n_frames * INDEX_ENTRY_SIZE
+    frames: list[list] = []
+    start = 0
+    for i in range(n_frames):
+        end, size = struct.unpack_from("<QQ", raw, index_off + i * INDEX_ENTRY_SIZE)
+        frames.append([raw[start:end], size])
+        start = end
+    return frames
+
+
+def rebuild(frames: list[list]) -> bytes:
+    """Concatenate the frames and re-emit the trailer index over them."""
+    out = bytearray(b"".join(comp for comp, _ in frames))
+    end = 0
+    for comp, size in frames:
+        end += len(comp)
+        out += struct.pack("<QQ", end, size)
+    out += struct.pack("<Q", len(frames))
+    return bytes(out)

--- a/tests/conformance/test_c_abi_runtime.py
+++ b/tests/conformance/test_c_abi_runtime.py
@@ -106,7 +106,8 @@ def test_a_library_without_the_symbols_is_a_load_failure() -> None:
 
 
 def test_read_array_at_accepts_a_null_destination_for_a_zero_byte_array(tmp_path: Path) -> None:
-    """A zero-byte read must succeed even with a null destination.
+    """
+    A zero-byte read must succeed even with a null destination.
 
     ``pv.Sphere()`` has no lines, verts, or strips, so its
     ``lines_connectivity``, ``verts_connectivity`` and ``strips_connectivity``

--- a/tests/conformance/test_concurrent_append.py
+++ b/tests/conformance/test_concurrent_append.py
@@ -1,0 +1,244 @@
+"""
+Two appends against one container, running at the same time.
+
+One append runs against a container at a time, and
+:func:`pyvista_zstd.append_arrays` enforces it rather than asking callers to.
+An append is a read-modify-write, so two of them at once each commit "what was
+there plus mine" and the second to land replaces the first's arrays -- with both
+callers told they succeeded. Checking for that at the end does not recover it:
+before the lock went in, four appends doing equal work reached their commits so
+close together that not one of them saw another's result, and three of the four
+sets of arrays vanished with every caller reporting success.
+
+The exclusion is a lock file created exclusively beside the container, because
+exclusive creation is the one primitive every target this builds for implements
+the same way -- ``flock`` returns success on the WebAssembly target without
+locking anything. A second append meanwhile is refused at once rather than
+queued.
+
+Two things are asserted here, and the second is the one that matters: appends
+that run at the same time are serialised rather than interleaved, and a caller
+told its append succeeded finds its arrays in the file afterwards.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import time
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+import pyvista as pv
+
+import pyvista_zstd as pz
+from pyvista_zstd import _capi
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# Big enough that copying its body takes long enough to replace the file
+# underneath the copy, and small enough to be cheap to write. Random doubles
+# barely compress, so the container is about this size on disk too.
+BULK_DIMENSION = 160
+
+WRITERS = 4
+"""Concurrent appends in the racing test. One per array, all released together."""
+
+RACE_TIMEOUT_S = 120.0
+"""Ceiling on any wait here; every one of them is normally over in well under a second."""
+
+_CHILD = f"""
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+import pyvista_zstd as pz
+from pyvista_zstd import _capi
+
+container, ready, go, name, seed = sys.argv[1:6]
+payload = np.random.default_rng(int(seed)).random(1 << 18)
+
+Path(ready).touch()
+deadline = time.monotonic() + {RACE_TIMEOUT_S}
+while not Path(go).exists():
+    if time.monotonic() > deadline:
+        print("timeout", flush=True)
+        raise SystemExit(1)
+
+# Refused while another append holds the container, so retry until it lets go:
+# the point of the lock is that the work is serialised, not that it is dropped.
+deadline = time.monotonic() + {RACE_TIMEOUT_S}
+while True:
+    try:
+        pz.append_arrays(container, {{name: payload}})
+    except _capi.ContainerBusyError:
+        if time.monotonic() > deadline:
+            print("busy", flush=True)
+            break
+        continue
+    except _capi.ContainerChangedError:
+        print("changed", flush=True)
+        break
+    except _capi.PvzstdError as err:
+        print(f"status {{err.status}}", flush=True)
+        break
+    else:
+        print("ok", flush=True)
+        break
+"""
+
+
+def _bulk(seed: int) -> pv.DataSet:
+    ds = pv.ImageData(dimensions=(BULK_DIMENSION,) * 3)
+    ds.point_data["bulk_f64"] = np.random.default_rng(seed).random(ds.n_points)
+    return ds
+
+
+def _wait_for(predicate, what: str) -> object:
+    """Spin until *predicate* returns something truthy, and return it."""
+    deadline = time.monotonic() + RACE_TIMEOUT_S
+    while True:
+        found = predicate()
+        if found:
+            return found
+        if time.monotonic() > deadline:
+            pytest.fail(f"waited {RACE_TIMEOUT_S}s for {what}")
+
+
+def _staging_files(container: Path) -> list[Path]:
+    """Whatever an in-flight or abandoned append has left beside *container*."""
+    return sorted(container.parent.glob(f"{container.name}.append.*"))
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="Windows will not replace a file another process holds open, so the collision cannot be staged there",
+)
+def test_a_container_replaced_mid_append_is_refused_rather_than_overwritten(tmp_path: Path) -> None:
+    """
+    An append whose container is replaced while it works reports it and writes nothing.
+
+    The collision is driven rather than raced for. The child's staging file
+    cannot exist before the child has opened and parsed the container, so its
+    appearance is a point strictly after the read and strictly before the
+    commit -- which is exactly the interval the check exists to cover. The
+    replacement is a single ``os.replace``, against a body copy of some tens of
+    milliseconds, so what is timing-dependent is only the margin and not the
+    ordering.
+    """
+    container = tmp_path / "shared.pv"
+    pz.write(_bulk(11), container, progress_bar=False)
+
+    # What the other writer commits: the same container with its own array.
+    theirs = tmp_path / "theirs.pv"
+    shutil.copyfile(container, theirs)
+    pz.append_arrays(theirs, {"step_1_theirs": np.arange(8, dtype=np.int64)})
+    replacement = theirs.read_bytes()
+
+    ready = tmp_path / "ready"
+    go = tmp_path / "go"
+    child = subprocess.Popen(  # noqa: S603
+        [sys.executable, "-c", _CHILD, str(container), str(ready), str(go), "step_1_ours", "5"],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        _wait_for(ready.exists, "the child to finish importing")
+        go.touch()
+        _wait_for(lambda: _staging_files(container), "the child's append to open its staging file")
+        theirs.replace(container)
+        verdict = child.communicate(timeout=RACE_TIMEOUT_S)[0].strip()
+    finally:
+        child.kill()
+
+    assert verdict == "changed", (
+        f"the append reported {verdict!r} for a container that was replaced while it was staging"
+    )
+    assert container.read_bytes() == replacement, "the refused append overwrote the other writer's result"
+    assert _staging_files(container) == [], "the refused append left its staging file behind"
+
+
+def test_concurrent_appends_are_serialised_and_lose_nothing(tmp_path: Path) -> None:
+    """
+    Genuinely concurrent, not sequential: every writer is released at once.
+
+    Each child imports and builds its array first, touches a file to say it is
+    ready, and then spins on a shared release file, so the appends themselves
+    overlap rather than the interpreter startups. A child refused because
+    another append holds the container retries until it is let in, which is what
+    the refusal is for: the work is serialised, not dropped.
+
+    Without the lock this fails on its last assertion and not its first -- every
+    child reports success and most of their arrays are not in the file.
+    """
+    container = tmp_path / "shared.pv"
+    pz.write(_bulk(3), container, progress_bar=False)
+    before = pz.read(container).point_data["bulk_f64"]
+
+    go = tmp_path / "go"
+    names = [f"step_1_writer{i}" for i in range(WRITERS)]
+    children = []
+    for i, name in enumerate(names):
+        ready = tmp_path / f"ready{i}"
+        children.append(
+            (
+                name,
+                ready,
+                subprocess.Popen(  # noqa: S603
+                    [sys.executable, "-c", _CHILD, str(container), str(ready), str(go), name, str(i)],
+                    stdout=subprocess.PIPE,
+                    text=True,
+                ),
+            )
+        )
+    try:
+        for _, ready, _proc in children:
+            _wait_for(ready.exists, "every child to finish importing")
+        go.touch()
+        verdicts = {name: proc.communicate(timeout=RACE_TIMEOUT_S)[0].strip() for name, _, proc in children}
+    finally:
+        for _, _, proc in children:
+            proc.kill()
+
+    assert set(verdicts.values()) == {"ok"}, (
+        f"appends that retry until the container is free should all get in eventually: {verdicts}"
+    )
+
+    final = pz.read(container)
+    assert np.array_equal(final.point_data["bulk_f64"], before), "a concurrent append damaged the container"
+    landed = set(pz.AppendReader(container).field_array_names)
+    assert set(names) <= landed, (
+        f"{set(names) - landed} were reported as appended and are not in the container; "
+        "one append committed over another's result"
+    )
+    assert _staging_files(container) == [], "a finished append left its staging file behind"
+    assert not (tmp_path / f"{container.name}.append.lock").exists(), "an append kept its lock"
+
+
+def test_a_lock_left_by_a_killed_append_refuses_the_next_one(tmp_path: Path) -> None:
+    """
+    The cost of locking with a file, asserted rather than left to be discovered.
+
+    A process killed mid-append leaves its lock behind and every later append is
+    refused until the file is deleted. That is the trade the lock makes, so the
+    refusal names the file and clears the moment it goes.
+    """
+    container = tmp_path / "locked.pv"
+    pz.write(_bulk(9), container, progress_bar=False)
+    committed = container.read_bytes()
+
+    stale = tmp_path / f"{container.name}.append.lock"
+    stale.touch()
+    with pytest.raises(_capi.ContainerBusyError, match=r"locked\.pv\.append\.lock"):
+        pz.append_arrays(container, {"step_1_blocked": np.arange(8, dtype=np.int64)})
+    assert container.read_bytes() == committed, "a refused append touched the container"
+
+    stale.unlink()
+    pz.append_arrays(container, {"step_1_blocked": np.arange(8, dtype=np.int64)})
+    assert "step_1_blocked" in pz.AppendReader(container).field_array_names

--- a/tests/conformance/test_crafted_containers.py
+++ b/tests/conformance/test_crafted_containers.py
@@ -20,6 +20,8 @@ import ctypes
 import struct
 from typing import TYPE_CHECKING
 
+from container_surgery import rebuild
+from container_surgery import split_frames
 import numpy as np
 import pytest
 import pyvista as pv
@@ -30,9 +32,6 @@ from pyvista_zstd import _capi
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-INDEX_ENTRY_SIZE = 16
-"""Bytes per trailer index entry: two little-endian u64 fields."""
 
 POISON_NDIM = 2**29
 """
@@ -75,38 +74,14 @@ def container(tmp_path: Path) -> bytes:
     return path.read_bytes()
 
 
-def _split(raw: bytes) -> list[list]:
-    """Return ``[compressed_bytes, declared_size]`` per frame, in file order."""
-    (n_frames,) = struct.unpack("<Q", raw[-8:])
-    index_off = len(raw) - 8 - n_frames * INDEX_ENTRY_SIZE
-    frames: list[list] = []
-    start = 0
-    for i in range(n_frames):
-        end, size = struct.unpack_from("<QQ", raw, index_off + i * INDEX_ENTRY_SIZE)
-        frames.append([raw[start:end], size])
-        start = end
-    return frames
-
-
-def _rebuild(frames: list[list]) -> bytes:
-    """Concatenate the frames and re-emit the trailer index over them."""
-    out = bytearray(b"".join(comp for comp, _ in frames))
-    end = 0
-    for comp, size in frames:
-        end += len(comp)
-        out += struct.pack("<QQ", end, size)
-    out += struct.pack("<Q", len(frames))
-    return bytes(out)
-
-
 def _patch_first_header(raw: bytes, mutate) -> bytes:
     """Rewrite frame 0 -- always an array header -- through *mutate*."""
-    frames = _split(raw)
+    frames = split_frames(raw)
     plain = zstd.ZstdDecompressor().decompress(frames[0][0], max_output_size=1 << 20)
     patched = mutate(bytearray(plain))
     frames[0][0] = zstd.ZstdCompressor(level=3).compress(bytes(patched))
     frames[0][1] = len(patched)
-    return _rebuild(frames)
+    return rebuild(frames)
 
 
 def _status_from_path(raw: bytes, tmp_path: Path) -> int:
@@ -142,7 +117,7 @@ def _both_doors(raw: bytes, tmp_path: Path) -> tuple[int, int]:
 
 def test_the_control_container_opens_through_both_doors(container: bytes, tmp_path: Path) -> None:
     """Rebuilt but unmodified, the container must still parse, or nothing below means anything."""
-    rebuilt = _rebuild(_split(container))
+    rebuilt = rebuild(split_frames(container))
     assert _both_doors(rebuilt, tmp_path) == (_capi._STATUS_OK, _capi._STATUS_OK)  # noqa: SLF001
 
 
@@ -170,9 +145,9 @@ def test_an_absurd_declared_size_is_refused_before_the_allocation(container: byt
     -- Emscripten's default -- turns that throw into ``abort()`` rather than
     into ``PVZSTD_E_NOMEM``.
     """
-    frames = _split(container)
+    frames = split_frames(container)
     frames[0][1] = POISON_DECOMPRESSED_SIZE
-    raw = _rebuild(frames)
+    raw = rebuild(frames)
 
     expected = (_capi._STATUS_FORMAT, _capi._STATUS_FORMAT)  # noqa: SLF001
     assert _both_doors(raw, tmp_path) == expected, (
@@ -196,7 +171,7 @@ def test_a_highly_compressible_array_still_reads(tmp_path: Path) -> None:
     pz.write(ds, path, progress_bar=False)
 
     raw = path.read_bytes()
-    declared = max(size for _, size in _split(raw))
+    declared = max(size for _, size in split_frames(raw))
     assert declared > 8 * len(raw), (
         f"the container is {len(raw)} bytes and its largest frame declares {declared}; "
         "this input did not compress enough to test the bound"

--- a/tests/conformance/test_oversized_allocations.py
+++ b/tests/conformance/test_oversized_allocations.py
@@ -1,0 +1,166 @@
+"""
+An allocation the append and stream paths cannot make comes back as a status.
+
+Both paths size a buffer from a 64-bit length out of the container's trailer,
+and both used to wrap that resize in ``catch (const std::bad_alloc &)``. A
+resize past the container type's ``max_size()`` does not throw that -- it throws
+``std::length_error``, which is not a ``bad_alloc``, so the narrow handler never
+caught it on any target. The reader was widened first; these are the same
+handler in the other translation units.
+
+``POISON_DECOMPRESSED_SIZE`` is answered by a different mechanism on each
+target, and the assertions accept either, because the crafted file is the same
+file on both:
+
+* On a 64-bit host it is past every standard library's ``max_size()``, so the
+  resize throws ``std::length_error`` and the widened handler is what turns it
+  into ``PVZSTD_E_NOMEM`` instead of letting it out of the library.
+* On a 32-bit target -- a WebAssembly build is one -- it is also past
+  ``SIZE_MAX``, so the guard now in front of the resize refuses it as
+  ``PVZSTD_E_FORMAT`` and no allocation is attempted at all.
+
+The writer's three sites are not driven from here. Two of them size themselves
+from a ``std::string`` the writer just built, so there is no length to poison;
+the third takes ``nbytes`` from the caller, and a caller able to pass a length
+past ``SIZE_MAX`` is one that could not have allocated the buffer it describes.
+Their handlers were widened for the same reason, but a public entry point
+cannot reach them, and a seam added to make it possible would be testing the
+seam.
+"""
+
+from __future__ import annotations
+
+import ctypes
+from typing import TYPE_CHECKING
+
+from container_surgery import rebuild
+from container_surgery import split_frames
+import numpy as np
+import pytest
+import pyvista as pv
+
+import pyvista_zstd as pz
+from pyvista_zstd import _capi
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+POISON_DECOMPRESSED_SIZE = 2**64 - 2**32 + 2**31
+"""
+A declared frame size no allocator on any target can serve.
+
+Above ``PTRDIFF_MAX``, so a 64-bit ``resize`` refuses it by throwing
+``std::length_error`` rather than by asking the allocator for it -- which is the
+throw the narrow handler could not catch. Its low 32 bits are ``2**31``, so a
+32-bit build that narrowed it instead of refusing it would still ask for 2 GiB
+rather than truncating to something small enough to succeed quietly.
+"""
+
+# PVZSTD_E_FORMAT and PVZSTD_E_NOMEM. Which one comes back is a property of the
+# target's size_t, not of the file; both mean the allocation was refused.
+REFUSALS = (2, 5)
+
+APPENDED = {"step_1_ids": np.arange(16, dtype=np.int64)}
+
+
+def _dataset() -> pv.DataSet:
+    rng = np.random.default_rng(5)
+    ds = pv.Sphere(theta_resolution=10, phi_resolution=10)
+    ds.point_data["scal_f64"] = rng.random(ds.n_points)
+    return ds
+
+
+@pytest.fixture
+def container(tmp_path: Path) -> bytes:
+    """Write a small single-dataset container and return its bytes."""
+    path = tmp_path / "surgery_source.pv"
+    pz.write(_dataset(), path, progress_bar=False)
+    return path.read_bytes()
+
+
+def _poison_file_metadata_size(raw: bytes) -> bytes:
+    """
+    Declare an impossible decompressed size for the file-metadata payload.
+
+    That frame is the last one, and it is the first thing both an append and a
+    stream open decompress -- so the poisoned length reaches the resize before
+    anything else in either path can refuse the file for another reason.
+    """
+    frames = split_frames(raw)
+    frames[-1][1] = POISON_DECOMPRESSED_SIZE
+    return rebuild(frames)
+
+
+def _stream_open(path: Path) -> int:
+    """Open *path* for streaming and return the status, freeing on success."""
+    lib = _capi._load()  # noqa: SLF001
+    lib.pvzstd_stream_open.restype = ctypes.c_int
+    lib.pvzstd_stream_open.argtypes = [ctypes.c_char_p, ctypes.POINTER(ctypes.c_void_p)]
+    lib.pvzstd_stream_free.restype = None
+    lib.pvzstd_stream_free.argtypes = [ctypes.c_void_p]
+
+    handle = ctypes.c_void_p()
+    status = int(lib.pvzstd_stream_open(str(path).encode("utf-8"), ctypes.byref(handle)))
+    if status == _capi._STATUS_OK:  # noqa: SLF001
+        lib.pvzstd_stream_free(handle)
+    else:
+        assert not handle, "a refused open must not hand back a stream"
+    return status
+
+
+def test_the_control_container_still_appends_and_streams(container: bytes, tmp_path: Path) -> None:
+    """Rebuilt but unpoisoned, the container must still work, or nothing below means anything."""
+    path = tmp_path / "control.pv"
+    path.write_bytes(rebuild(split_frames(container)))
+
+    assert _stream_open(path) == _capi._STATUS_OK  # noqa: SLF001
+    pz.append_arrays(path, APPENDED)
+    assert np.array_equal(pz.read_array(path, "step_1_ids"), APPENDED["step_1_ids"])
+
+
+def test_append_refuses_a_frame_size_no_allocator_can_serve(container: bytes, tmp_path: Path) -> None:
+    """
+    The append reports the refusal rather than letting the throw out.
+
+    Before the handler was widened, ``std::length_error`` walked past it to the
+    entry point's ``catch (...)``. That is a status too, so what this pins is
+    the property rather than the route: no exception crosses the C ABI, and no
+    build that turns the throw into an abort meets one here.
+    """
+    path = tmp_path / "poisoned.pv"
+    path.write_bytes(_poison_file_metadata_size(container))
+
+    with pytest.raises(_capi.PvzstdError) as caught:
+        pz.append_arrays(path, APPENDED)
+    assert caught.value.status in REFUSALS, (
+        f"a frame declaring {POISON_DECOMPRESSED_SIZE} decompressed bytes was refused with "
+        f"status {caught.value.status}, which is neither a format error nor an allocation failure"
+    )
+
+
+def test_append_leaves_the_container_alone_when_it_refuses(container: bytes, tmp_path: Path) -> None:
+    """The refused append writes nothing: it fails while reading, before it stages anything."""
+    path = tmp_path / "poisoned.pv"
+    poisoned = _poison_file_metadata_size(container)
+    path.write_bytes(poisoned)
+
+    with pytest.raises(_capi.PvzstdError):
+        pz.append_arrays(path, APPENDED)
+
+    assert path.read_bytes() == poisoned
+    assert list(tmp_path.glob("poisoned.pv.*")) == [], "the refused append left a staging file behind"
+
+
+def test_stream_open_refuses_a_frame_size_no_allocator_can_serve(container: bytes, tmp_path: Path) -> None:
+    """
+    The streaming open reports it too, which is the one site the widening changes.
+
+    Every other handler here sits under an entry point whose ``catch (...)``
+    already produced the same status. This one sits under an open that closes
+    the file and deletes the half-built stream on every failure it *returns*, so
+    a throw walking past the handler leaked both.
+    """
+    path = tmp_path / "poisoned.pv"
+    path.write_bytes(_poison_file_metadata_size(container))
+
+    assert _stream_open(path) in REFUSALS

--- a/tests/test_append.py
+++ b/tests/test_append.py
@@ -15,6 +15,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import os
 import struct
 from typing import TYPE_CHECKING
 
@@ -211,27 +212,40 @@ def test_kept_frames_are_byte_identical_after_append(tmp_path, base_grid) -> Non
 # --------------------------------------------------------------------------
 # 4. Crash / partial-write safety.
 # --------------------------------------------------------------------------
+@pytest.mark.skipif(
+    os.name == "nt" or (hasattr(os, "geteuid") and os.geteuid() == 0),
+    reason="denying file creation in a directory needs POSIX permissions and a non-root user",
+)
 def test_failed_append_does_not_destroy_prior_blocks(tmp_path, base_grid) -> None:
-    """An append that cannot complete leaves the original file fully readable."""
-    path = _write_base(tmp_path / "c.pv", base_grid)
+    """
+    An append that cannot complete leaves the original file fully readable.
+
+    The failure is staged by taking away the right to create the staging file:
+    an append names it through the operating system now, so there is no name to
+    occupy in advance the way there was when every append used the same one.
+    """
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    path = _write_base(vault / "c.pv", base_grid)
     append_arrays(path, {"first": np.arange(50, dtype=np.float64)})
     committed = path.read_bytes()
 
-    staging = path.with_suffix(path.suffix + ".append.tmp")
-    staging.mkdir()
-    with pytest.raises(_capi.PvzstdError, match="I/O error"):
-        append_arrays(path, {"second": np.arange(99, dtype=np.float64)})
+    vault.chmod(0o500)  # readable and searchable, but nothing new may be created
+    try:
+        with pytest.raises(_capi.PvzstdError, match="I/O error"):
+            append_arrays(path, {"second": np.arange(99, dtype=np.float64)})
 
-    assert path.read_bytes() == committed
-    with AppendReader(path) as r:
-        assert "first" in r.field_array_names
-        assert "second" not in r.field_array_names
-        assert np.array_equal(r.read_array("first"), np.arange(50, dtype=np.float64))
+        assert path.read_bytes() == committed
+        with AppendReader(path) as r:
+            assert "first" in r.field_array_names
+            assert "second" not in r.field_array_names
+            assert np.array_equal(r.read_array("first"), np.arange(50, dtype=np.float64))
+    finally:
+        vault.chmod(0o700)
 
-    staging.rmdir()
     append_arrays(path, {"second": np.arange(99, dtype=np.float64)})
     assert np.array_equal(read_array(path, "second"), np.arange(99, dtype=np.float64))
-    assert not staging.exists()
+    assert list(vault.glob("c.pv.append.*")) == []
 
 
 def test_reader_close_releases_the_file_and_reads_reopen(tmp_path, base_grid) -> None:
@@ -252,13 +266,15 @@ def test_manually_truncated_file_does_not_corrupt_committed(tmp_path, base_grid)
     A stale, half-written temp file is irrelevant.
 
     The committed .pv is the source of truth and reads fine; a fresh
-    append still works and cleans up.
+    append still works, and stages somewhere else rather than picking up
+    whatever a crashed one left.
     """
     path = _write_base(tmp_path / "t.pv", base_grid)
     append_arrays(path, {"good": np.arange(33, dtype=np.float64)})
     good_bytes = path.read_bytes()
 
-    # Simulate a stale, truncated temp file from a prior crashed append.
+    # A stale, truncated temp file from a prior crashed append, under a name
+    # that append staged into before the name came from the operating system.
     tmp = path.with_suffix(path.suffix + ".append.tmp")
     tmp.write_bytes(good_bytes[: len(good_bytes) // 2])
 


### PR DESCRIPTION
Two appends against one container lose data with nothing reported. Both stage at the same fixed `<path>.append.tmp`, both rename onto the container, and the second commits a body it copied before the first's arrays existed. Both callers are told they succeeded. Driving four concurrent appends of one array set each, 32 runs out of 32 ended with one array set present and three gone.

Resolves https://github.com/pyvista/pyvista-zstd/issues/38, resolves https://github.com/pyvista/pyvista-zstd/issues/53. ABI goes 10 to 11: two new statuses, no signature changes.

## One writer at a time, enforced

Each call now stages into a file the operating system names (`mkstemp`, `GetTempFileNameA`), so no two callers share a staging path. That alone does not fix it: append is a read-modify-write, and two calls that each read, add and commit still lose one set. A check just before the rename does not recover it either, since two appends doing equal work reach their commits microseconds apart and neither check sees the other's result.

So there is an advisory lock, `<path>.append.lock`, created exclusively and held for the call. A second append returns `PVZSTD_E_BUSY` immediately, having read and written nothing. It does not wait. A library has no business deciding how long its caller blocks, and the caller knows whether a retry or a queue is right.

Exclusive create is the primitive rather than `flock` because it behaves the same on every target this builds for. `flock` on the WebAssembly target returns success without locking anything, which is worse than not offering the guarantee.

The cost is a lock that outlives a killed process. An append that dies while holding it leaves the file behind and every later append to that container returns `PVZSTD_E_BUSY` until someone deletes it. That is the trade taken deliberately: a named, visible, documented recovery in place of one writer's arrays vanishing silently. The header and `doc/c_api.rst` both name the file and say when removing it is safe.

Anything that replaces the container without taking that lock is a separate case, and the lock cannot cover it. Each call re-checks before committing that its path still names the container it read, and returns `PVZSTD_E_CHANGED` if not. That is a check over the staging window, not over the microseconds between the check and the rename, and it is documented as such.

Streams take no lock and are covered by none. A stream writes in place, so it has no commit point at which to notice another writer and no staging file to hold back. Neither new status can come out of the stream API. The header says so.

## The twelve narrow catch sites

`std::vector::resize` past `max_size()` throws `std::length_error`, which `catch (const std::bad_alloc &)` never catches on any target. #50 widened the reader's handler for exactly this and left twelve sites with the same shape: four in `append.cpp`, three in `writer.cpp`, four in `stream.cpp`, and `detail.h`'s `out->resize(ZSTD_compressBound(n))`.

All twelve now catch `std::exception`, and each narrowing that feeds one is guarded ahead of the throw so the handler is the backstop rather than the mechanism. The write, append and stream paths size their allocations from data the caller already holds, so these are far less exposed than the reader was, but "less exposed" is not a property that survives the next caller.

`ZSTD_compressBound` is the one worth naming: it adds overhead to the input size, so an input near the address-space limit produces a bound above it on a 32-bit target. Guarded by dividing rather than multiplying, same shape as the container-field guards.

## Tests

`tests/conformance/test_concurrent_append.py` drives real concurrent appends and asserts every array set is either present or reported `PVZSTD_E_BUSY`, never silently absent. It fails against the pre-change build. `tests/conformance/test_oversized_allocations.py` covers the allocation guards. `container_surgery.py` grew the helper both use; `test_crafted_containers.py` now imports it instead of carrying its own copy.
