### PR TITLE
Run the pre-commit job on pull requests only

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -26,6 +26,11 @@ jobs:
   pre-commit:
     name: pre-commit
     runs-on: ubuntu-24.04
+    # Pull requests only. One of the hooks is no-commit-to-branch, which exists
+    # to stop a commit landing on main directly and so fails by definition when
+    # the run is the push of a merge onto main. The pull request that produced
+    # that merge already ran every hook against the same tree.
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
`main` has been red since the pre-commit job was added in #54. The job runs on push as well as on pull requests, and one of the hooks is `no-commit-to-branch`, which fails by definition when the tree it is looking at is a commit on `main`. Every merge onto `main` has failed that job since, including #55 and #56.

Gating the job to pull requests is the fix rather than dropping the hook. The hook is there to stop a commit landing on `main` directly, which is a thing worth refusing locally, and the pull request that produced a merge has already run every hook against the same tree, so the push run was checking nothing the PR run had not.
