### PR TITLE
Give the docs job the write permission its gh-pages push needs

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -13,8 +13,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Least privilege by default. The release job raises its own, and is the only
-# job here that needs more than a checkout.
+# Least privilege by default. The two jobs that write something back to the
+# repository -- the docs deploy and the release -- raise their own.
 permissions:
   contents: read
 
@@ -44,6 +44,11 @@ jobs:
   doc:
     name: Build Documentation
     runs-on: ubuntu-24.04
+    # On a tag this job pushes the rendered docs to gh-pages, which the
+    # workflow-level contents: read cannot do: the push is rejected with a 403
+    # and takes the release job down with it, since release needs this one.
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
### Summary

The v0.4.0 tag build failed and took the release with it. The docs job pushes
`gh-pages` on a tag, but #52 left it with the workflow-level `contents: read`:

```
remote: Permission to pyvista/pyvista-zstd.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/pyvista/pyvista-zstd.git/': The requested URL returned error: 403
```

`release` lists `doc` in `needs`, so the 403 skipped the release job entirely —
no GitHub release, and PyPI is still on 0.3.1 — even though all 24 unit-test
jobs, every wheel job and the sdist passed on that same run.

### Changes

- `contents: write` on the docs job, which is what
  `peaceiris/actions-gh-pages` needs to commit and push `gh-pages`.
- Corrected the workflow-level comment; release is no longer the only job that
  raises its own permissions.

Permissions are per-job, not per-step, so this cannot be narrowed to the
`if: startsWith(github.ref, 'refs/tags/v')` deploy step alone. Every other job
keeps `contents: read`.

### Testing

- `check-jsonschema --builtin-schema vendor.github-workflows` — passes.
- Parsed the workflow and confirmed the resulting permission map: only `doc`
  and `release` raise anything, everything else still inherits `contents: read`.

The real proof is the re-run of the v0.4.0 tag, which is the next step after
this merges.

### Agent disclosure

Diagnosed and written by a coding agent (Claude Code) at my direction; I have
reviewed it.
