### PR TITLE
Update pre-commit hooks and configure Dependabot for updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,15 @@ updates:
         patterns:
           - "*"
     rebase-strategy: "disabled"
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 100
+    labels:
+      - "maintenance"
+      - "dependencies"
+    groups:
+      pre-commit:
+        patterns:
+          - "*"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v21.1.2
+    rev: v23.1.0
     hooks:
       - id: clang-format
         types_or: [c, c++]
         # The vendored zstd must stay byte-identical to its upstream release.
         exclude: ^cpp/third_party/
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
+    rev: v2.4.3
     hooks:
       - id: codespell
         args: ["doc src tests", "*.py *.rst *.md"]
@@ -21,7 +21,7 @@ repos:
         exclude: ^pytest-pyvista/ext/
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.1.0
+    rev: v2.3.1
     hooks:
       - id: mypy
         exclude: ^(doc/|tests/|benchmarks/)
@@ -43,12 +43,12 @@ repos:
 
   # this validates our github workflow files
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.2
+    rev: 0.38.0
     hooks:
       - id: check-github-workflows
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.16
+    rev: v0.16.5
     hooks:
       - id: ruff-check
         args: [--fix, --show-fixes]
@@ -56,7 +56,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.8.4
+    rev: v3.9.6
     hooks:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ line-length = 120
 docstring-code-format = true
 
 [tool.ruff.lint]
-ignore = ["COM812", "D203", "D212", "ISC001"]
+ignore = ["COM812", "CPY", "D203", "D212", "ISC001"]
 select = ["ALL"]
 
 [tool.ruff.lint.isort]


### PR DESCRIPTION
- Update pre-commit hooks using `prek update`
- Ignore ruff's `CPY` rules
- Configure Dependabot for updates