### PR TITLE
Publish linux aarch64 wheels

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -144,7 +144,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # Linux carries its architecture per entry rather than deriving it from
+        # the runner, so the arch a lane builds is readable next to the lane.
+        # aarch64 is built natively on a GitHub-hosted arm64 runner; QEMU would
+        # be the alternative and is an order of magnitude slower.
+        include:
+          - os: ubuntu-latest
+            archs_linux: x86_64
+          - os: ubuntu-24.04-arm
+            archs_linux: aarch64
+          - os: macos-latest
+          - os: windows-latest
 
     steps:
       - uses: actions/checkout@v7
@@ -160,10 +170,10 @@ jobs:
           CIBW_SKIP: "*-musllinux_* cp310-macosx_* cp310-win*"
           # glibc 2.17 has no Pillow wheel; the cp312 wheel still proves the library loads.
           CIBW_TEST_SKIP: "cp310-manylinux*"
-          # The platforms named here are the ones README.rst promises a wheel
-          # for. Anything outside them installs from the sdist and needs a C++
-          # compiler; keep the two in step.
-          CIBW_ARCHS_LINUX: x86_64
+          # The platforms named here and in the matrix are the ones README.rst
+          # promises a wheel for. Anything outside them installs from the sdist
+          # and needs a C++ compiler; keep the two in step.
+          CIBW_ARCHS_LINUX: ${{ matrix.archs_linux }}
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_ARCHS_WINDOWS: AMD64
           CIBW_ENVIRONMENT: PVZSTD_BUILD_CORE=1

--- a/README.rst
+++ b/README.rst
@@ -59,18 +59,18 @@ Install with:
 The package is a C++ library with a Python wrapper around it, so an install is
 either a prebuilt wheel or a compile. Wheels are published for:
 
-+---------+--------------------------------------------------+
-| Linux   | x86_64 (manylinux2014 and manylinux_2_28)        |
-+---------+--------------------------------------------------+
-| macOS   | x86_64 and arm64                                 |
-+---------+--------------------------------------------------+
-| Windows | AMD64                                            |
-+---------+--------------------------------------------------+
++---------+-------------------------------------------------------+
+| Linux   | x86_64 and aarch64 (manylinux2014 and manylinux_2_28) |
++---------+-------------------------------------------------------+
+| macOS   | x86_64 and arm64                                      |
++---------+-------------------------------------------------------+
+| Windows | AMD64                                                 |
++---------+-------------------------------------------------------+
 
-Everywhere else -- musl-based Linux, Linux on aarch64, Windows on ARM -- ``pip``
-falls back to the source distribution and builds the core during the install,
-which needs a C++17 compiler on the machine. CMake does not: it comes from the
-build requirements. A machine without a compiler fails the install rather than
+Everywhere else -- musl-based Linux, Windows on ARM -- ``pip`` falls back to
+the source distribution and builds the core during the install, which needs a
+C++17 compiler on the machine. CMake does not: it comes from the build
+requirements. A machine without a compiler fails the install rather than
 producing a package that imports and cannot read anything.
 
 Compatible with all VTK dataset types. Uses

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,10 +66,17 @@ version_file = "src/pyvista_zstd/_version.py"
 # NumPy <= 2.2.6, the last release with a cp310 manylinux2014 wheel, so the old
 # image still resolves; 3.12 resolves NumPy 2.5.x, whose lowest x86_64 tag is
 # manylinux_2_27 and which will not build on the 2014 image's gcc 10.2.1.
+#
+# Both Linux architectures name both images. The wheels are py3-none-<platform>,
+# so leaving aarch64 on the manylinux_2_28 default for every interpreter would
+# give the cp310 and cp312 builds one filename and the second would land on top
+# of the first.
 [tool.cibuildwheel]
+manylinux-aarch64-image = "manylinux_2_28"
 manylinux-x86_64-image = "manylinux_2_28"
 
 [[tool.cibuildwheel.overrides]]
+manylinux-aarch64-image = "manylinux2014"
 manylinux-x86_64-image = "manylinux2014"
 select = "cp310-*"
 


### PR DESCRIPTION
0.4.0 moved the package from a `py3-none-any` wheel to platform wheels, and the release matrix builds x86_64 Linux, both macOS architectures and win_amd64. There is no linux aarch64 wheel, so `pip` on arm64 Linux falls back to the sdist and compiles the C++ core during the install. On a machine without a C++17 toolchain that install fails outright:

```
CMake Error: CMake was unable to find a build program corresponding to "Unix Makefiles".
CMake Error: CMAKE_CXX_COMPILER not set, after EnableLanguage
pvzstd: the C++ core failed to build, and it is what the package is
```

0.3.1 was pure Python and installed fine there, so this is a regression for arm64 Linux users.

The change:

- adds `ubuntu-24.04-arm` to the `wheels` matrix and builds `aarch64` on it. The runner is GitHub-hosted and free for public repositories, so this is a native build rather than QEMU emulation.
- moves `CIBW_ARCHS_LINUX` into the matrix as a per-entry value, keeping the arch a lane builds visible beside the lane.
- names both manylinux images for aarch64 in `pyproject.toml`. The wheels are `py3-none-<platform>`, and aarch64 defaults to `manylinux_2_28` for every interpreter, so without the override the cp310 and cp312 builds would share one filename.
- lists linux aarch64 in the README table, which the workflow comment asks to be kept in step.

`cibuildwheel --print-build-identifiers --platform linux --archs aarch64` yields `cp310-manylinux_aarch64` and `cp312-manylinux_aarch64`, so the existing `CIBW_SKIP` and `CIBW_TEST_SKIP: cp310-manylinux*` both apply unchanged. The release job collects wheels with `pattern: wheels-*`, which picks up the new `wheels-ubuntu-24.04-arm` artifact.
