### PR TITLE
Assign dataset UIDs in write order so identical meshes write identical bytes

### DIFF
--- a/doc/c_api.rst
+++ b/doc/c_api.rst
@@ -603,8 +603,9 @@ with
 
 Against a container written by ``pyvista_zstd.write``, it prints something like::
 
-   00007c31d6209960points: dtype <f4, ndim 2, 10104 bytes
+   0000000000000000points: dtype <f4, ndim 2, 10104 bytes
 
-The UID prefix on the name is the dataset UID the format carries. It derives
-from an object address in the writing process, so it is not stable across
-processes and must be treated as an opaque token, never parsed for meaning.
+The UID prefix on the name is the dataset UID the format carries. The Python
+writer assigns it as an index in write order, so the same dataset writes the
+same bytes in any process; files written by older releases carry an object
+address instead. Treat it as an opaque token, never parsed for meaning.

--- a/doc/format/container-v2.md
+++ b/doc/format/container-v2.md
@@ -216,9 +216,9 @@ filtered bytes as-is silently corrupts the array (`:864-868`).
 
 ### 3.1 Name encoding
 
-Array names are prefixed by a 16-character dataset UID (`_make_ds_id`, `:633`,
-`f"{id(ds):016x}"`), so a frame name looks like
-`00007fb61b52bb80scal_f32__point_data`. Association is carried as a **name
+Array names are prefixed by a 16-character dataset UID
+(`Writer._make_ds_id`, a zero-padded hex index assigned in write order), so a
+frame name looks like `0000000000000000scal_f32__point_data`. Association is carried as a **name
 suffix**, not a separate field: `__point_data`, `__cell_data`. Topology and
 geometry frames use bare suffix-free names under the same UID prefix —
 `points`, `celltypes`, `cells_offset`, `cells_connectivity`, and for PolyData
@@ -226,8 +226,10 @@ the `verts_ / lines_ / strips_ / polys_` `_offset` and `_connectivity` pairs.
 The two JSON frames are `__ds_metadata` (UID-prefixed) and
 `__pyvista_zstd_metadata` (**not** UID-prefixed).
 
-Because the UID derives from a Python object address, it is **not stable across
-processes** and must be treated as an opaque token, never parsed for meaning.
+The index makes output reproducible: content-identical datasets write
+byte-identical files in any process. Files from releases before 0.4.2 carry a
+Python object address instead, so a reader must treat the UID as an opaque
+token, never parsed for meaning.
 Empty topology arrays are still written as full (header, payload) pairs with
 `shape=(0,)`.
 

--- a/src/pyvista_zstd/pyvista_zstd.py
+++ b/src/pyvista_zstd/pyvista_zstd.py
@@ -243,13 +243,15 @@ class DataSetMetadata:
     offset: int | None = None
 
     @classmethod
-    def from_dataset(
+    def from_dataset(  # noqa: PLR0913
         cls,
         ds: pv.DataSet,
         point_info: dict[str, ArrayInfo],
         cell_info: dict[str, ArrayInfo],
         field_info: dict[str, ArrayInfo],
         fixed_cell_sizes: dict[str, int],
+        *,
+        uid: str,
     ) -> DataSetMetadata:
         """Create metadata from a dataset."""
         # Many pyvista calls require intermediate object assembly, side step or
@@ -275,7 +277,7 @@ class DataSetMetadata:
         cd = ds.cell_data
         kwargs: dict[str, Any] = {
             "ds_type": type(ds).__name__,
-            "uid": _make_ds_id(ds),
+            "uid": uid,
             "n_points": ds.n_points,
             "points_dtype": str(points_dtype) if points_dtype is not None else None,
             "n_cells": ds.n_cells,
@@ -426,26 +428,25 @@ def _extract_cell_array(
     return _numpy_to_vtk_cells(segments[offset_key], segments[conn_key])
 
 
-def _add_arrays_pointset(ds: PointSet, arrays: dict[str, NDArray[Any]]) -> None:
-    arrays[f"{_make_ds_id(ds)}{POINTS_KEY}"] = ds.points
+def _add_arrays_pointset(ds_id: str, ds: PointSet, arrays: dict[str, NDArray[Any]]) -> None:
+    arrays[f"{ds_id}{POINTS_KEY}"] = ds.points
 
 
-def _add_arrays_rgrid(ds: RectilinearGrid, arrays: dict[str, NDArray[Any]]) -> None:
+def _add_arrays_rgrid(ds_id: str, ds: RectilinearGrid, arrays: dict[str, NDArray[Any]]) -> None:
     if ds.n_points:
-        ds_id = _make_ds_id(ds)
         arrays[f"{ds_id}{RGRID_X_SUFFIX}"] = ds.x
         arrays[f"{ds_id}{RGRID_Y_SUFFIX}"] = ds.y
         arrays[f"{ds_id}{RGRID_Z_SUFFIX}"] = ds.z
 
 
 def _add_arrays_polydata(
+    ds_id: str,
     ds: PolyData,
     arrays: dict[str, NDArray[Any]],
     fixed_cell_sizes: dict[str, int],
     *,
     force_int32: bool = True,
 ) -> None:
-    ds_id = _make_ds_id(ds)
     arrays[f"{ds_id}{POINTS_KEY}"] = ds.points
     # Every one of these holds point ids, so the point count bounds them all.
     max_point_id = ds.n_points - 1
@@ -467,15 +468,13 @@ def _add_arrays_polydata(
 
 
 def _add_arrays_ugrid(
+    ds_id: str,
     ds: UnstructuredGrid,
     arrays: dict[str, NDArray[Any]],
     fixed_cell_sizes: dict[str, int],
-    ds_id: str | None = None,
     *,
     force_int32: bool = True,
 ) -> None:
-    if ds_id is None:
-        ds_id = _make_ds_id(ds)
     arrays[f"{ds_id}{POINTS_KEY}"] = ds.points
     arrays[f"{ds_id}{CELL_TYPES_KEY}"] = ds.celltypes
 
@@ -521,19 +520,18 @@ def _add_arrays_ugrid(
 
 
 def _add_arrays_esgrid(
+    ds_id: str,
     ds: ExplicitStructuredGrid,
     arrays: dict[str, NDArray[Any]],
     fixed_cell_sizes: dict[str, int],
     *,
     force_int32: bool = True,
 ) -> None:
-    ds_id = _make_ds_id(ds)
     ugrid = ds.cast_to_unstructured_grid()
-    _add_arrays_ugrid(ugrid, arrays, fixed_cell_sizes, ds_id, force_int32=force_int32)
+    _add_arrays_ugrid(ds_id, ugrid, arrays, fixed_cell_sizes, force_int32=force_int32)
 
 
-def _add_arrays_sgrid(ds: StructuredGrid, arrays: dict[str, NDArray[Any]]) -> None:
-    ds_id = _make_ds_id(ds)
+def _add_arrays_sgrid(ds_id: str, ds: StructuredGrid, arrays: dict[str, NDArray[Any]]) -> None:
     arrays[f"{ds_id}{POINTS_KEY}"] = ds.points
 
 
@@ -619,12 +617,6 @@ def write(  # noqa: PLR0913
     )
 
 
-def _make_ds_id(ds: DataSet) -> str:
-    """Make a unique dataset ID using the memory address."""
-    # padded for 32-bit
-    return f"{id(ds):016x}"
-
-
 class Writer:
     """Class to write a pyvista-zstd file."""
 
@@ -640,33 +632,37 @@ class Writer:
         self._ds = pv.wrap(ds)
         self._uses_fixed_width_cells = False
 
-        # used to hold a reference to the dataset. This is necessary for
-        # multiblocks to avoid having them collected and getting duplicate
-        # memory addresses
+        # Sequential UIDs keyed by object identity: a dataset shared between
+        # blocks is stored once, and the payload carries no process state.
+        self._ids: dict[int, str] = {}
         self._refs: list[DataSet | MultiBlock] = []
+
+    def _make_ds_id(self, ds: DataSet | MultiBlock) -> str:
+        key = id(ds)
+        if key not in self._ids:
+            self._refs.append(ds)
+            self._ids[key] = f"{len(self._ids):0{UID_N_CHAR}x}"
+        return self._ids[key]
 
     def _add_ds_arrays(self, ds: DataSet, *, force_int32: bool) -> None:  # noqa: C901, PLR0912
         """Extract dataset data as arrays."""
-        # Hold on to a reference of the dataset to avoid it being collected
-        # while we generate all memory IDs
-        self._refs.append(ds)
-        ds_id = _make_ds_id(ds)
+        ds_id = self._make_ds_id(ds)
         fixed_cell_sizes: dict[str, int] = {}
 
         if isinstance(ds, PolyData):
-            _add_arrays_polydata(ds, self._arrays, fixed_cell_sizes, force_int32=force_int32)
+            _add_arrays_polydata(ds_id, ds, self._arrays, fixed_cell_sizes, force_int32=force_int32)
         elif isinstance(ds, UnstructuredGrid):
-            _add_arrays_ugrid(ds, self._arrays, fixed_cell_sizes, force_int32=force_int32)
+            _add_arrays_ugrid(ds_id, ds, self._arrays, fixed_cell_sizes, force_int32=force_int32)
         elif isinstance(ds, ExplicitStructuredGrid):
-            _add_arrays_esgrid(ds, self._arrays, fixed_cell_sizes, force_int32=force_int32)
+            _add_arrays_esgrid(ds_id, ds, self._arrays, fixed_cell_sizes, force_int32=force_int32)
         elif isinstance(ds, ImageData):
             pass
         elif isinstance(ds, StructuredGrid):
-            _add_arrays_sgrid(ds, self._arrays)
+            _add_arrays_sgrid(ds_id, ds, self._arrays)
         elif isinstance(ds, PointSet):
-            _add_arrays_pointset(ds, self._arrays)
+            _add_arrays_pointset(ds_id, ds, self._arrays)
         elif isinstance(ds, RectilinearGrid):
-            _add_arrays_rgrid(ds, self._arrays)
+            _add_arrays_rgrid(ds_id, ds, self._arrays)
         elif isinstance(ds, MultiBlock):
             # placeholder, array insertion order matters
             self._arrays[f"{ds_id}{MULTIBLOCK_METADATA_KEY}"] = None
@@ -677,7 +673,7 @@ class Writer:
                 if ds_child is None:
                     child_ids.append(EMPTY_DS)
                 else:
-                    child_ids.append(_make_ds_id(ds_child))
+                    child_ids.append(self._make_ds_id(ds_child))
                     self._add_ds_arrays(ds_child, force_int32=force_int32)
 
             # edge case where multiblock can contain a NoneType key
@@ -710,7 +706,7 @@ class Writer:
             field_info[key] = ArrayInfo(shape=array.shape, dtype=str(array.dtype))
 
         # supply dataset metadata
-        ds_meta = DataSetMetadata.from_dataset(ds, point_info, cell_info, field_info, fixed_cell_sizes)
+        ds_meta = DataSetMetadata.from_dataset(ds, point_info, cell_info, field_info, fixed_cell_sizes, uid=ds_id)
         self._arrays[f"{ds_id}{DS_METADATA_KEY}"] = ds_meta.to_array()
         self._uses_fixed_width_cells = self._uses_fixed_width_cells or bool(fixed_cell_sizes)
 
@@ -758,6 +754,7 @@ class Writer:
 
         # no need to hold onto any references as all IDs have been written
         self._refs = []
+        self._ids = {}
 
 
 def _add_data(ds_id: str, ds: DataSet, segment_dict: dict[str, Any]) -> None:

--- a/tests/test_pyvista_zstd.py
+++ b/tests/test_pyvista_zstd.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
+import subprocess
+import sys
 from typing import TYPE_CHECKING
 import warnings
 
@@ -731,6 +733,71 @@ def test_multiblock_two_empty_blocks(ugrid: UnstructuredGrid, tmp_path: Path) ->
     assert [out.get_block_name(i) for i in range(out.n_blocks)] == ["a", "real", "b"]
     assert out["a"] is None
     assert out["b"] is None
+
+
+def _reproducible_polydata() -> PolyData:
+    mesh = pv.Sphere(theta_resolution=6, phi_resolution=6)
+    mesh.point_data["temperature"] = np.arange(mesh.n_points, dtype=np.float32)
+    mesh.cell_data["region"] = np.arange(mesh.n_cells, dtype=np.int32)
+    mesh.field_data["tag"] = np.array([7])
+    return mesh
+
+
+def _reproducible_ugrid() -> UnstructuredGrid:
+    return pv.ImageData(dimensions=(4, 4, 4)).cast_to_unstructured_grid()
+
+
+def _reproducible_multiblock() -> MultiBlock:
+    shared = _reproducible_ugrid()
+    rgrid = pv.RectilinearGrid(np.arange(3.0), np.arange(2.0), np.arange(2.0))
+    inner = MultiBlock([shared, None, rgrid])
+    return MultiBlock([_reproducible_polydata(), inner, shared, pv.ImageData(dimensions=(3, 3, 3))])
+
+
+@pytest.mark.parametrize("build", [_reproducible_polydata, _reproducible_ugrid, _reproducible_multiblock])
+def test_write_is_reproducible(build, tmp_path: Path) -> None:
+    """
+    Two separately constructed, content-identical datasets write identical bytes.
+
+    Writing one object twice is stable even when the UID leaks its address,
+    so the two datasets here must be distinct objects.
+    """
+    first, second = build(), build()
+    assert first is not second
+    pyvista_zstd.write(first, tmp_path / "first.pv")
+    pyvista_zstd.write(second, tmp_path / "second.pv")
+    assert (tmp_path / "first.pv").read_bytes() == (tmp_path / "second.pv").read_bytes()
+
+
+def test_write_is_reproducible_across_processes(tmp_path: Path) -> None:
+    """The payload carries no process state: two interpreters write the same bytes."""
+    script = (
+        "import sys, pyvista as pv, pyvista_zstd\n"
+        "pyvista_zstd.write(pv.Sphere(theta_resolution=6, phi_resolution=6), sys.argv[1])\n"
+    )
+    paths = [tmp_path / "first.pv", tmp_path / "second.pv"]
+    for path in paths:
+        subprocess.run([sys.executable, "-c", script, str(path)], check=True)  # noqa: S603
+    assert paths[0].read_bytes() == paths[1].read_bytes()
+
+
+def test_dataset_uids_are_traversal_order(ugrid: UnstructuredGrid, polydata: PolyData, tmp_path: Path) -> None:
+    """UIDs are indices assigned in write order, and a block referenced twice keeps one."""
+    inner = MultiBlock([polydata, ugrid])
+    mblock = MultiBlock([ugrid, inner, None])
+    tmp_filename = tmp_path / "tmp.pv"
+    pyvista_zstd.write(mblock, tmp_filename)
+
+    reader = pyvista_zstd.Reader(tmp_filename)
+    frame_names = reader._metadata.frame_names  # noqa: SLF001
+    metadata_uids = [
+        name[: impl.UID_N_CHAR]
+        for name in frame_names
+        if name.endswith((impl.DS_METADATA_KEY, impl.MULTIBLOCK_METADATA_KEY))
+    ]
+    assert metadata_uids == [f"{i:0{impl.UID_N_CHAR}x}" for i in range(4)]
+    assert reader[0].uid == reader[1][1].uid
+    assert reader[2].uid == impl.EMPTY_DS
 
 
 def test_esgrid(esgrid: ExplicitStructuredGrid, tmp_path: Path) -> None:


### PR DESCRIPTION
Every frame name was prefixed with the writing process's `id(ds)`, so two content-identical meshes wrote different files and any content-hash check over `.pv` output (dedup, caching) silently missed. Resolves #64.

The writer now hands out UIDs as zero-padded hex indices in write order, keyed by object identity, so a dataset shared between blocks still gets one UID and is stored once. The on-disk format is unchanged: still a 16-char prefix the C++ core treats as opaque, and files from earlier releases still read.

The regression tests write two separately constructed datasets, and two separate interpreters, then compare bytes. Writing one object twice was already stable and would not have caught this.
