### PR TITLE
Allow application-specific extensions for incremental PV readers

### DIFF
--- a/src/pyvista_zstd/append.py
+++ b/src/pyvista_zstd/append.py
@@ -190,6 +190,9 @@ class AppendReader:
     ----------
     filename : pathlib.Path | str
         Path to a ``.pv`` file.
+    check_extension : bool, default: True
+        Set False for an application-specific filename extension. Container
+        validation remains enabled.
     backend : str, optional
         Deprecated and ignored; passing it raises a :class:`DeprecationWarning`.
 
@@ -206,15 +209,18 @@ class AppendReader:
         filename: Path | str,
         *,
         backend: str | None = None,
+        check_extension: bool = True,
     ) -> None:
         """
         Open ``filename`` for field-array reads.
 
         ``backend`` is deprecated and ignored.
+        ``check_extension=False`` permits application-specific filenames;
+        container validation remains enabled.
         """
         _warn_backend_deprecated(backend)
         self._core: CoreReader | None = None
-        self._path = _checked_path(filename)
+        self._path = _checked_path(filename) if check_extension else Path(filename)
 
     @property
     def _core_reader(self) -> CoreReader:

--- a/src/pyvista_zstd/pyvista_zstd.py
+++ b/src/pyvista_zstd/pyvista_zstd.py
@@ -1187,6 +1187,9 @@ class Reader:
         A whole container, contiguous. Exactly one of *filename* and *buffer*
         is given; a buffer has no suffix to check, so its bytes decide whether
         it is a container.
+    check_extension : bool, default: True
+        Set False for an application-specific filename extension. Container
+        contents and version are still validated normally.
     backend : str, optional
         Deprecated and ignored; passing it raises a :class:`DeprecationWarning`.
 
@@ -1242,11 +1245,14 @@ class Reader:
         *,
         buffer: bytes | bytearray | memoryview | NDArray[Any] | None = None,
         backend: str | None = None,
+        check_extension: bool = True,
     ) -> None:
         """
         Initialize the decompressor.
 
         ``backend`` is deprecated and ignored.
+        ``check_extension=False`` permits application-specific filenames;
+        container contents and version are still validated normally.
         """
         _warn_backend_deprecated(backend)
         if (filename is None) == (buffer is None):
@@ -1262,7 +1268,7 @@ class Reader:
         self._closed = False
 
         # Only a path carries a suffix to judge; a buffer is judged by its bytes.
-        if self._filename is not None and self._filename.suffix not in SUPPORTED_READ_SUFFIXES:
+        if check_extension and self._filename is not None and self._filename.suffix not in SUPPORTED_READ_SUFFIXES:
             msg = f"Filename must end in one of {SUPPORTED_READ_SUFFIXES}, not '{self._filename.suffix}'"
             raise ValueError(msg)
 

--- a/tests/test_application_extension.py
+++ b/tests/test_application_extension.py
@@ -1,0 +1,44 @@
+"""Application suffixes do not bypass container validation."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import pyvista as pv
+
+from pyvista_zstd import AppendReader
+from pyvista_zstd import Reader
+from pyvista_zstd import append_arrays
+from pyvista_zstd import write
+from pyvista_zstd._capi import ContainerFormatError
+
+
+def test_application_extension_partial_read(tmp_path) -> None:
+    """Custom filenames retain selective geometry and field reads."""
+    original = tmp_path / "data.pv"
+    mesh = pv.PolyData(np.array([[0.0, 0.0, 0.0]]))
+    write(mesh, original)
+    values = np.arange(18, dtype=np.float32).reshape(2, 3, 3)
+    append_arrays(original, {"modes": values}, shuffle=True)
+    target = original.rename(tmp_path / "data.gmm")
+    with pytest.raises(ValueError, match="Filename"):
+        Reader(target)
+    with pytest.raises(ValueError, match="Filename"):
+        AppendReader(target)
+    with Reader(target, check_extension=False) as reader:
+        reader.selected_field_arrays = set()
+        actual = reader.read()
+        assert not actual.field_data
+        np.testing.assert_array_equal(actual.points, mesh.points)
+    with AppendReader(target, check_extension=False) as reader:
+        assert reader.read_array("modes").tobytes() == values.tobytes()
+
+
+def test_application_extension_still_validates_contents(tmp_path) -> None:
+    """Disabling the suffix check does not allow invalid container bytes."""
+    target = tmp_path / "bad.gmm"
+    target.write_bytes(b"not a PV container")
+    with pytest.raises(RuntimeError, match="container"):
+        Reader(target, check_extension=False)
+    with AppendReader(target, check_extension=False) as reader, pytest.raises(ContainerFormatError):
+        reader.read_array("modes")


### PR DESCRIPTION
Applications that store PV containers under their own extension currently have to rename or copy files before using the public readers. Add `check_extension=False` to `Reader` and `AppendReader` so applications can read those files directly while preserving normal container and version validation. The default suffix checks remain unchanged.

Validation: 244 tests passed, including the native reader/writer/append/stream parity suite; coverage 96.15%. New tests cover selective reads under `.gmm`, default rejection of that suffix, and rejection of invalid container contents.
